### PR TITLE
Updates for Unity 5 compatibility.

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/Sample/Demo/Scripts/Objects/ColorChanger.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/Sample/Demo/Scripts/Objects/ColorChanger.cs
@@ -42,7 +42,7 @@ public class ColorChanger : MonoBehaviour, IColorChanger
 	#region Init
 	void Awake()
 	{
-		_material = renderer.materials[materialID];
+		_material = GetComponent<Renderer>().materials[materialID];
 	}
 	#endregion
 

--- a/OSVR-Unity/Assets/OSVRUnity/src/OsvrPostEffectsBase.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/OsvrPostEffectsBase.cs
@@ -112,9 +112,10 @@ public class OsvrPostEffectsBase : MonoBehaviour {
 			return false;
 		}
 		
-		if(needDepth)
+		if (needDepth) {
 			GetComponent<Camera>().depthTextureMode |= DepthTextureMode.Depth;	
-		
+		}
+
 		return true;
 	}
 

--- a/OSVR-Unity/Assets/OSVRUnity/src/OsvrPostEffectsBase.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/OsvrPostEffectsBase.cs
@@ -113,7 +113,7 @@ public class OsvrPostEffectsBase : MonoBehaviour {
 		}
 		
 		if(needDepth)
-			camera.depthTextureMode |= DepthTextureMode.Depth;	
+			GetComponent<Camera>().depthTextureMode |= DepthTextureMode.Depth;	
 		
 		return true;
 	}


### PR DESCRIPTION
According to the Unity 5 docs, renderer and camera shortcut properties are deprecated in Unity 5, to be replaced by GetComponent<Renderer>() and GetComponent<Camera>() respectively. After making these changes below, I was able to successfully build the project in Unity 5.

https://github.com/OSVR/OSVR-Unity/issues/26