### PR TITLE
Move DisplayInterface.GetDeviceDescription code to DeviceDescription.Parse

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/DeviceDescriptor.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DeviceDescriptor.cs
@@ -23,6 +23,11 @@ using System.Collections;
 using System.Text;
 
 //a class for storing information about a device based on it's json descriptor file
+using Newtonsoft.Json;
+using System.IO;
+using System;
+
+
 public class DeviceDescriptor {
 
     //filename
@@ -223,4 +228,106 @@ public class DeviceDescriptor {
         .Append("rotate_180 = ").AppendLine(Rotate180.ToString());
        return jsonPrinter.ToString();
     }
+
+	/// <summary>
+	/// This function will parse the device parameters from a device descriptor json file using Newstonsoft
+	///
+	/// Returns a DeviceDescriptor object containing stored json values.
+	/// </summary>
+	public static DeviceDescriptor Parse(string deviceDescriptorJson)
+	{
+		if (deviceDescriptorJson == null) {
+			throw new ArgumentNullException ("deviceDescriptorJson");
+		}
+
+		//create a device descriptor object for storing the parsed json in an object
+		DeviceDescriptor deviceDescriptor;
+		JsonTextReader reader;
+		
+		
+		reader = new JsonTextReader(new StringReader(deviceDescriptorJson));
+		if(reader != null)
+		{
+			deviceDescriptor = new DeviceDescriptor();
+		}
+		else
+		{
+			Debug.LogError("No Device Descriptor detected.");
+			return null;
+		}
+		
+		//parsey
+		while (reader.Read())
+		{
+			if (reader.Value != null && reader.ValueType == typeof(String))
+			{
+				string parsedJson = reader.Value.ToString().ToLower();
+				switch(parsedJson)
+				{
+				case "vendor":
+					deviceDescriptor.Vendor = reader.ReadAsString();
+					break;
+				case "model":
+					deviceDescriptor.Model = reader.ReadAsString();
+					break;
+				case "version":
+					deviceDescriptor.Version = reader.ReadAsString();
+					break;
+				case "note":
+					deviceDescriptor.Note = reader.ReadAsString();
+					break;
+				case "monocular_horizontal":
+					deviceDescriptor.MonocularHorizontal = float.Parse(reader.ReadAsString());
+					break;
+				case "monocular_vertical":
+					deviceDescriptor.MonocularVertical = float.Parse(reader.ReadAsString());
+					break;
+				case "overlap_percent":
+					deviceDescriptor.OverlapPercent = float.Parse(reader.ReadAsString());
+					break;
+				case "pitch_tilt":
+					deviceDescriptor.PitchTilt = float.Parse(reader.ReadAsString());
+					break;
+				case "width":
+					deviceDescriptor.Width = int.Parse(reader.ReadAsString());
+					break;
+				case "height":
+					deviceDescriptor.Height = int.Parse(reader.ReadAsString());
+					break;
+				case "video_inputs":
+					deviceDescriptor.VideoInputs = int.Parse(reader.ReadAsString());
+					break;
+				case "display_mode":
+					deviceDescriptor.DisplayMode = reader.ReadAsString();
+					break;
+				case "k1_red":
+					deviceDescriptor.K1Red = float.Parse(reader.ReadAsString());
+					break;
+				case "k1_green":
+					deviceDescriptor.K1Green = float.Parse(reader.ReadAsString());
+					break;
+				case "k1_blue":
+					deviceDescriptor.K1Blue = float.Parse(reader.ReadAsString());
+					break;
+				case "right_roll":
+					deviceDescriptor.RightRoll = float.Parse(reader.ReadAsString());
+					break;
+				case "left_roll":
+					deviceDescriptor.LeftRoll = float.Parse(reader.ReadAsString());
+					break;
+				case "center_proj_x":
+					deviceDescriptor.CenterProjX = float.Parse(reader.ReadAsString());
+					break;
+				case "center_proj_y":
+					deviceDescriptor.CenterProjY = float.Parse(reader.ReadAsString());
+					break;
+				case "rotate_180":
+					deviceDescriptor.Rotate180 = int.Parse(reader.ReadAsString());
+					break;
+				}
+			}
+		}
+		
+		return deviceDescriptor;
+	}
 }

--- a/OSVR-Unity/Assets/OSVRUnity/src/DeviceDescriptor.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DeviceDescriptor.cs
@@ -229,105 +229,105 @@ public class DeviceDescriptor {
        return jsonPrinter.ToString();
     }
 
-	/// <summary>
-	/// This function will parse the device parameters from a device descriptor json file using Newstonsoft
-	///
-	/// Returns a DeviceDescriptor object containing stored json values.
-	/// </summary>
-	public static DeviceDescriptor Parse(string deviceDescriptorJson)
-	{
-		if (deviceDescriptorJson == null) {
-			throw new ArgumentNullException ("deviceDescriptorJson");
-		}
+    /// <summary>
+    /// This function will parse the device parameters from a device descriptor json file using Newstonsoft
+    ///
+    /// Returns a DeviceDescriptor object containing stored json values.
+    /// </summary>
+    public static DeviceDescriptor Parse(string deviceDescriptorJson)
+    {
+        if (deviceDescriptorJson == null) {
+            throw new ArgumentNullException ("deviceDescriptorJson");
+        }
 
-		//create a device descriptor object for storing the parsed json in an object
-		DeviceDescriptor deviceDescriptor;
-		JsonTextReader reader;
-		
-		
-		reader = new JsonTextReader(new StringReader(deviceDescriptorJson));
-		if(reader != null)
-		{
-			deviceDescriptor = new DeviceDescriptor();
-		}
-		else
-		{
-			Debug.LogError("No Device Descriptor detected.");
-			return null;
-		}
-		
-		//parsey
-		while (reader.Read())
-		{
-			if (reader.Value != null && reader.ValueType == typeof(String))
-			{
-				string parsedJson = reader.Value.ToString().ToLower();
-				switch(parsedJson)
-				{
-				case "vendor":
-					deviceDescriptor.Vendor = reader.ReadAsString();
-					break;
-				case "model":
-					deviceDescriptor.Model = reader.ReadAsString();
-					break;
-				case "version":
-					deviceDescriptor.Version = reader.ReadAsString();
-					break;
-				case "note":
-					deviceDescriptor.Note = reader.ReadAsString();
-					break;
-				case "monocular_horizontal":
-					deviceDescriptor.MonocularHorizontal = float.Parse(reader.ReadAsString());
-					break;
-				case "monocular_vertical":
-					deviceDescriptor.MonocularVertical = float.Parse(reader.ReadAsString());
-					break;
-				case "overlap_percent":
-					deviceDescriptor.OverlapPercent = float.Parse(reader.ReadAsString());
-					break;
-				case "pitch_tilt":
-					deviceDescriptor.PitchTilt = float.Parse(reader.ReadAsString());
-					break;
-				case "width":
-					deviceDescriptor.Width = int.Parse(reader.ReadAsString());
-					break;
-				case "height":
-					deviceDescriptor.Height = int.Parse(reader.ReadAsString());
-					break;
-				case "video_inputs":
-					deviceDescriptor.VideoInputs = int.Parse(reader.ReadAsString());
-					break;
-				case "display_mode":
-					deviceDescriptor.DisplayMode = reader.ReadAsString();
-					break;
-				case "k1_red":
-					deviceDescriptor.K1Red = float.Parse(reader.ReadAsString());
-					break;
-				case "k1_green":
-					deviceDescriptor.K1Green = float.Parse(reader.ReadAsString());
-					break;
-				case "k1_blue":
-					deviceDescriptor.K1Blue = float.Parse(reader.ReadAsString());
-					break;
-				case "right_roll":
-					deviceDescriptor.RightRoll = float.Parse(reader.ReadAsString());
-					break;
-				case "left_roll":
-					deviceDescriptor.LeftRoll = float.Parse(reader.ReadAsString());
-					break;
-				case "center_proj_x":
-					deviceDescriptor.CenterProjX = float.Parse(reader.ReadAsString());
-					break;
-				case "center_proj_y":
-					deviceDescriptor.CenterProjY = float.Parse(reader.ReadAsString());
-					break;
-				case "rotate_180":
-					deviceDescriptor.Rotate180 = int.Parse(reader.ReadAsString());
-					break;
-				}
-			}
-		}
-		
-		return deviceDescriptor;
-	}
+        //create a device descriptor object for storing the parsed json in an object
+        DeviceDescriptor deviceDescriptor;
+        JsonTextReader reader;
+        
+        
+        reader = new JsonTextReader(new StringReader(deviceDescriptorJson));
+        if(reader != null)
+        {
+            deviceDescriptor = new DeviceDescriptor();
+        }
+        else
+        {
+            Debug.LogError("No Device Descriptor detected.");
+            return null;
+        }
+        
+        //parsey
+        while (reader.Read())
+        {
+            if (reader.Value != null && reader.ValueType == typeof(String))
+            {
+                string parsedJson = reader.Value.ToString().ToLower();
+                switch(parsedJson)
+                {
+                case "vendor":
+                    deviceDescriptor.Vendor = reader.ReadAsString();
+                    break;
+                case "model":
+                    deviceDescriptor.Model = reader.ReadAsString();
+                    break;
+                case "version":
+                    deviceDescriptor.Version = reader.ReadAsString();
+                    break;
+                case "note":
+                    deviceDescriptor.Note = reader.ReadAsString();
+                    break;
+                case "monocular_horizontal":
+                    deviceDescriptor.MonocularHorizontal = float.Parse(reader.ReadAsString());
+                    break;
+                case "monocular_vertical":
+                    deviceDescriptor.MonocularVertical = float.Parse(reader.ReadAsString());
+                    break;
+                case "overlap_percent":
+                    deviceDescriptor.OverlapPercent = float.Parse(reader.ReadAsString());
+                    break;
+                case "pitch_tilt":
+                    deviceDescriptor.PitchTilt = float.Parse(reader.ReadAsString());
+                    break;
+                case "width":
+                    deviceDescriptor.Width = int.Parse(reader.ReadAsString());
+                    break;
+                case "height":
+                    deviceDescriptor.Height = int.Parse(reader.ReadAsString());
+                    break;
+                case "video_inputs":
+                    deviceDescriptor.VideoInputs = int.Parse(reader.ReadAsString());
+                    break;
+                case "display_mode":
+                    deviceDescriptor.DisplayMode = reader.ReadAsString();
+                    break;
+                case "k1_red":
+                    deviceDescriptor.K1Red = float.Parse(reader.ReadAsString());
+                    break;
+                case "k1_green":
+                    deviceDescriptor.K1Green = float.Parse(reader.ReadAsString());
+                    break;
+                case "k1_blue":
+                    deviceDescriptor.K1Blue = float.Parse(reader.ReadAsString());
+                    break;
+                case "right_roll":
+                    deviceDescriptor.RightRoll = float.Parse(reader.ReadAsString());
+                    break;
+                case "left_roll":
+                    deviceDescriptor.LeftRoll = float.Parse(reader.ReadAsString());
+                    break;
+                case "center_proj_x":
+                    deviceDescriptor.CenterProjX = float.Parse(reader.ReadAsString());
+                    break;
+                case "center_proj_y":
+                    deviceDescriptor.CenterProjY = float.Parse(reader.ReadAsString());
+                    break;
+                case "rotate_180":
+                    deviceDescriptor.Rotate180 = int.Parse(reader.ReadAsString());
+                    break;
+                }
+            }
+        }
+        
+        return deviceDescriptor;
+    }
 }

--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayInterface.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayInterface.cs
@@ -62,24 +62,24 @@ namespace OSVR
                 return GetDeviceDescription();
             }
 
-			/// <summary>
-			/// This function will parse the device parameters from a device descriptor json file using Newstonsoft
-			///
-			/// Returns a DeviceDescriptor object containing stored json values.
-			/// </summary>
-			public DeviceDescriptor GetDeviceDescription()
-			{
-				//create a device descriptor object for storing the parsed json in an object
-				DeviceDescriptor deviceDescriptor = DeviceDescriptor.Parse(_deviceDescriptorJson);
-				if (deviceDescriptor != null) {
-					if (JsonDescriptorFile != null) {
-						deviceDescriptor.FileName = JsonDescriptorFile.name;
-					} else {
-						deviceDescriptor.FileName = "No descriptor file has been assigned. Using parameters from /display";
-					}
-				}
-				return deviceDescriptor;
-			}
+            /// <summary>
+            /// This function will parse the device parameters from a device descriptor json file using Newstonsoft
+            ///
+            /// Returns a DeviceDescriptor object containing stored json values.
+            /// </summary>
+            public DeviceDescriptor GetDeviceDescription()
+            {
+                //create a device descriptor object for storing the parsed json in an object
+                DeviceDescriptor deviceDescriptor = DeviceDescriptor.Parse(_deviceDescriptorJson);
+                if (deviceDescriptor != null) {
+                    if (JsonDescriptorFile != null) {
+                        deviceDescriptor.FileName = JsonDescriptorFile.name;
+                    } else {
+                        deviceDescriptor.FileName = "No descriptor file has been assigned. Using parameters from /display";
+                    }
+                }
+                return deviceDescriptor;
+            }
         }
     }
 }

--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayInterface.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayInterface.cs
@@ -62,111 +62,24 @@ namespace OSVR
                 return GetDeviceDescription();
             }
 
-            /// <summary>
-            /// This function will parse the device parameters from a device descriptor json file using Newstonsoft
-            ///
-            /// Returns a DeviceDescriptor object containing stored json values.
-            /// </summary>
-            public DeviceDescriptor GetDeviceDescription()
-            {
-                //create a device descriptor object for storing the parsed json in an object
-                DeviceDescriptor deviceDescriptor;
-                JsonTextReader reader;
-               
-
-                reader = new JsonTextReader(new StringReader(_deviceDescriptorJson));
-                if(reader != null)
-                {
-                    deviceDescriptor = new DeviceDescriptor();
-                }
-                else
-                {
-                    Debug.LogError("No Device Descriptor detected.");
-                    return null;
-                }
-                if(JsonDescriptorFile != null)
-                {
-                    deviceDescriptor.FileName = JsonDescriptorFile.name;
-                }
-                else
-                {
-                    deviceDescriptor.FileName = "No descriptor file has been assigned. Using parameters from /display";
-                }
-                
-                //parsey
-                while (reader.Read())
-                {
-                    if (reader.Value != null && reader.ValueType == typeof(String))
-                    {
-                        string parsedJson = reader.Value.ToString().ToLower();
-                        switch(parsedJson)
-                        {
-                            case "vendor":
-                                deviceDescriptor.Vendor = reader.ReadAsString();
-                                break;
-                            case "model":
-                                deviceDescriptor.Model = reader.ReadAsString();
-                                break;
-                            case "version":
-                                deviceDescriptor.Version = reader.ReadAsString();
-                                break;
-                            case "note":
-                                deviceDescriptor.Note = reader.ReadAsString();
-                                break;
-                            case "monocular_horizontal":
-                                deviceDescriptor.MonocularHorizontal = float.Parse(reader.ReadAsString());
-                                break;
-                            case "monocular_vertical":
-                                deviceDescriptor.MonocularVertical = float.Parse(reader.ReadAsString());
-                                break;
-                            case "overlap_percent":
-                                deviceDescriptor.OverlapPercent = float.Parse(reader.ReadAsString());
-                                break;
-                            case "pitch_tilt":
-                                deviceDescriptor.PitchTilt = float.Parse(reader.ReadAsString());
-                                break;
-                            case "width":
-                                deviceDescriptor.Width = int.Parse(reader.ReadAsString());
-                                break;
-                            case "height":
-                                deviceDescriptor.Height = int.Parse(reader.ReadAsString());
-                                break;
-                            case "video_inputs":
-                                deviceDescriptor.VideoInputs = int.Parse(reader.ReadAsString());
-                                break;
-                            case "display_mode":
-                                deviceDescriptor.DisplayMode = reader.ReadAsString();
-                                break;
-                            case "k1_red":
-                                deviceDescriptor.K1Red = float.Parse(reader.ReadAsString());
-                                break;
-                            case "k1_green":
-                                deviceDescriptor.K1Green = float.Parse(reader.ReadAsString());
-                                break;
-                            case "k1_blue":
-                                deviceDescriptor.K1Blue = float.Parse(reader.ReadAsString());
-                                break;
-                            case "right_roll":
-                                deviceDescriptor.RightRoll = float.Parse(reader.ReadAsString());
-                                break;
-                            case "left_roll":
-                                deviceDescriptor.LeftRoll = float.Parse(reader.ReadAsString());
-                                break;
-                            case "center_proj_x":
-                                deviceDescriptor.CenterProjX = float.Parse(reader.ReadAsString());
-                                break;
-                            case "center_proj_y":
-                                deviceDescriptor.CenterProjY = float.Parse(reader.ReadAsString());
-                                break;
-                            case "rotate_180":
-                                deviceDescriptor.Rotate180 = int.Parse(reader.ReadAsString());
-                                break;
-                        }
-                    }
-                }
-
-                return deviceDescriptor;
-            }
+			/// <summary>
+			/// This function will parse the device parameters from a device descriptor json file using Newstonsoft
+			///
+			/// Returns a DeviceDescriptor object containing stored json values.
+			/// </summary>
+			public DeviceDescriptor GetDeviceDescription()
+			{
+				//create a device descriptor object for storing the parsed json in an object
+				DeviceDescriptor deviceDescriptor = DeviceDescriptor.Parse(_deviceDescriptorJson);
+				if (deviceDescriptor != null) {
+					if (JsonDescriptorFile != null) {
+						deviceDescriptor.FileName = JsonDescriptorFile.name;
+					} else {
+						deviceDescriptor.FileName = "No descriptor file has been assigned. Using parameters from /display";
+					}
+				}
+				return deviceDescriptor;
+			}
         }
     }
 }


### PR DESCRIPTION
DeviceDescription should have a static Parse method taking a json string value to handle parsing of the DeviceDescription. DisplayInterface.GetDeviceDescription should still handle sourcing the json value (either a static value or from '/display').

This will make it easier to migrate DeviceDescription into the core Managed-OSVR library in the future.