### PR TITLE
Improve DLL search path fixer.

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/ClientKit.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/ClientKit.cs
@@ -75,16 +75,9 @@ namespace OSVR
                 }
             }
 
-            /// <summary>
-            /// Static constructor that enhances the DLL search path to ensure dependent native dlls are found.
-            /// </summary>
-            static ClientKit()
-            {
-                DLLSearchPathFixer.fix();
-            }
-
             void Awake()
             {
+                DLLSearchPathFixer.fix();
                 DontDestroyOnLoad(gameObject);
             }
             void Start()
@@ -102,7 +95,6 @@ namespace OSVR
             void FixedUpdate()
             {
                 EnsureStarted();
-                //Debug.Log("ClientKit FixedUpdate: frame # " + Time.frameCount + " " + Time.time);
                 contextObject.update();
             }
           

--- a/OSVR-Unity/Assets/OSVRUnity/src/DLLSearchPathFixer.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DLLSearchPathFixer.cs
@@ -49,7 +49,7 @@ namespace OSVR
             private DLLSearchPathFixer()
             {
                 var currentPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Process);
-                Debug.Log(String.Format("Old PATH: {0}", currentPath));
+                //Debug.Log(String.Format("Old PATH: {0}", currentPath));
                 OrigDirs = new List<string>(currentPath.Split(Path.PathSeparator));
                 UnityDataDir = Application.dataPath;
                 UnityDataDirBackslashed = Application.dataPath.Replace("/", "\\");
@@ -65,7 +65,7 @@ namespace OSVR
                 allDirs.AddRange(OrigDirs);
 
                 var newPathString = String.Join(Path.PathSeparator.ToString(), allDirs.ToArray());
-                Debug.Log(String.Format("New PATH: {0}", newPathString));
+                //Debug.Log(String.Format("New PATH: {0}", newPathString));
                 Environment.SetEnvironmentVariable("PATH", newPathString, EnvironmentVariableTarget.Process);
             }
 

--- a/OSVR-Unity/Assets/OSVRUnity/src/DLLSearchPathFixer.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DLLSearchPathFixer.cs
@@ -17,8 +17,9 @@
 /// </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.IO;
-using System.Text;
+using UnityEngine;
 
 namespace OSVR
 {
@@ -33,30 +34,110 @@ namespace OSVR
             /// </summary>
             public static void fix()
             {
-                string[] dllPaths = {
-                    "Assets" + Path.DirectorySeparatorChar + "Plugins",
-                    "Assets"+ Path.DirectorySeparatorChar + "Plugins"+ Path.DirectorySeparatorChar + "x86", // todo don't hardcode this
-                    "StreamingAssets"+ Path.DirectorySeparatorChar + "Plugins",
-                    "StreamingAssets"+ Path.DirectorySeparatorChar + "Plugins"+ Path.DirectorySeparatorChar + "x86" // todo don't hardcode this
-                };
                 // Amend DLL search path - see http://forum.unity3d.com/threads/dllnotfoundexception-when-depend-on-another-dll.31083/#post-1042180
                 // for original inspiration for this code.
-                string currentPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Process);
-                string[] currentPaths = currentPath.Split(Path.PathSeparator);
-                StringBuilder paths = new StringBuilder();
-                foreach (string dllPath in dllPaths)
-                {
-                    String fullDllPath = Environment.CurrentDirectory + Path.DirectorySeparatorChar + dllPath;
-                    if (Array.IndexOf(currentPaths, fullDllPath) < 0)
-                    {
-                        paths.AppendFormat("{1}{0}", Path.PathSeparator, fullDllPath);
-                    }
-                }
-                // Keeps our new paths in front.
-                paths.Append(currentPath);
-                Environment.SetEnvironmentVariable("PATH", paths.ToString(), EnvironmentVariableTarget.Process);
+
+                var fixer = new DLLSearchPathFixer();
+                fixer.ConditionallyAddRelativeDir("Plugins");
+                fixer.ConditionallyAddRelativeDir(new List<String>() { "Plugins", IntPtr.Size == 4 ? "x86" : "x86_64" });
+                fixer.ApplyChanges();
             }
 
+            /// <summary>
+            /// Constructor for private use as a helper within the static fix() method.
+            /// </summary>
+            private DLLSearchPathFixer()
+            {
+                var currentPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Process);
+                Debug.Log(String.Format("Old PATH: {0}", currentPath));
+                OrigDirs = new List<string>(currentPath.Split(Path.PathSeparator));
+                UnityDataDir = Application.dataPath;
+                UnityDataDirBackslashed = Application.dataPath.Replace("/", "\\");
+            }
+
+            /// <summary>
+            /// Update the process environment PATH variable to contain the full list (entries new and old) of directories.
+            /// </summary>
+            private void ApplyChanges()
+            {
+                // Combine new and old dirs
+                var allDirs = new List<String>(NewDirs);
+                allDirs.AddRange(OrigDirs);
+
+                var newPathString = String.Join(Path.PathSeparator.ToString(), allDirs.ToArray());
+                Debug.Log(String.Format("New PATH: {0}", newPathString));
+                Environment.SetEnvironmentVariable("PATH", newPathString, EnvironmentVariableTarget.Process);
+            }
+
+            /// <summary>
+            /// If a directory specified relative to the Unity data dir is not yet in the PATH, add it.
+            /// </summary>
+            /// <param name="dirComponents">Components of a directory name relative to the Unity data dir.</param>
+            private void ConditionallyAddRelativeDir(List<string> dirComponents)
+            {
+                ConditionallyAddRelativeDir(PathTools.Combine(dirComponents));
+            }
+
+            /// <summary>
+            /// If a directory specified relative to the Unity data dir is not yet in the PATH, add it.
+            /// </summary>
+            /// <param name="dirComponents">A directory name relative to the Unity data dir.</param>
+            private void ConditionallyAddRelativeDir(string relativePortion)
+            {
+                if (IsRelativeDirIncludedInPath(relativePortion))
+                {
+                    // early out.
+                    return;
+                }
+                NewDirs.Add(PathTools.Combine(UnityDataDir, relativePortion));
+            }
+
+            /// <summary>
+            /// Checks to see if a directory specified relative to the Unity data dir is included in the path so far.
+            /// It checks using both forward-slashed and backslashed versions of the Unity data dir.
+            /// </summary>
+            /// <param name="relativePortion">Directory relative to the Unity data dir</param>
+            /// <returns>true if the given directory is included in the path so far</returns>
+            private bool IsRelativeDirIncludedInPath(string relativePortion)
+            {
+                return IsIncludedInPath(PathTools.Combine(UnityDataDir, relativePortion)) || IsIncludedInPath(PathTools.Combine(UnityDataDirBackslashed, relativePortion));
+            }
+
+            /// <summary>
+            /// Checks to see if a directory is included in the path so far (both new and old directories).
+            /// </summary>
+            /// <param name="dir">Directory name</param>
+            /// <returns>true if the given directory name is found in either the new or old directory lists.</returns>
+            private bool IsIncludedInPath(string dir)
+            {
+                return NewDirs.Contains(dir) || OrigDirs.Contains(dir);
+            }
+
+            private string UnityDataDir;
+            private string UnityDataDirBackslashed;
+            private List<string> NewDirs = new List<string>();
+            private List<string> OrigDirs;
+
+            /// <summary>
+            /// Utilities for combining path components with a wider variety of input data types than System.IO.Path.Combine
+            /// </summary>
+            private class PathTools
+            {
+                internal static string Combine(string a, string b)
+                {
+                    return Path.Combine(a, b);
+                }
+
+                internal static string Combine(string[] components)
+                {
+                    return String.Join(Path.DirectorySeparatorChar.ToString(), components);
+                }
+
+                internal static string Combine(List<String> components)
+                {
+                    return PathTools.Combine(components.ToArray());
+                }
+            }
         }
     }
 }

--- a/OSVR-Unity/CHANGES.md
+++ b/OSVR-Unity/CHANGES.md
@@ -3,8 +3,11 @@
 This is an abbreviated changelog for the OSVR Unity Plugin.
 
 Use git for a full changelog.
-##Recent Changes (updated 28-March-2015)
-##External Json File v0.1-56-gf2d8bab (20-March-2015)
+##Recent Changes (updated 31-March-2015)
+##DLL Search Path v0.1-69-gb80966b (31-March-2015)
+- The built executable will now find the plugins it needs in the _Data folder. Previously, the executable had to be in the same directory with Assets/Plugins. That is no longer necessary.
+
+##External Json File v0.1-56-gf2d8bab (28-March-2015)
 - The JSON file containing display configuration can now be read from a file at runtime. To do this, add a config file "hmd.json" to the _Data folder that is created in a build. The format of the JSON file has not changed at all. It is the same file you would drag-and-drop onto the DisplayInterface component on your VRDisplayTracked prefab. If "hmd.json" does not exist in the Data folder (and it won't by default unless you put it there), then the plugin will look for the JSON file assigned in the DisplayInterface component in your scene. If that also has not been assigned, it will fall back to reading OSVR's /display parameter (this will eventually be the default).
 
 ##Distortion v0.1-55-g046c709(20-March-2015)


### PR DESCRIPTION
- Use a class to keep track of state.
- Use the Unity Application data dir property instead of current directory + "Assets"
- Handle looking in x86 vs x86_64 - does not fully fix the 64-bit support but it's one step.

@DuFF14 can you test this with Unity Pro and make sure it works, both in the editor and the compiled build player? It should solve the issue of looking in the wrong place in compiled builds.