### PR TITLE
install-managed-osvr.cmd was always showing up as modified. Removing …

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,3 @@
-# Auto detect text files and perform LF normalization
-* text=auto
-
 # Source files - keep them lf
 *.cs text eol=lf
 


### PR DESCRIPTION
…this line fixed the issue. Have core.crlf = false and core.eol = lf currently.

http://stackoverflow.com/a/15687910/1121765