### PR TITLE
Adjust head update

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
@@ -130,10 +130,10 @@ namespace OSVR
                 }
             }
 
-            //Called after a camera finishes rendering the scene.
+            //Called before a camera renders the scene.
             //the goal here is to update the client often to make sure we have the most recent tracker data
             //this helps reduce latency
-            void OnPostRender()
+            void OnPreRender()
             {
                 clientKit.context.update();
             }

--- a/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
@@ -46,6 +46,8 @@ namespace OSVR
             [HideInInspector]
             public Transform cachedTransform;
             [HideInInspector]
+            public VRHead head;
+            [HideInInspector]
             public K1RadialDistortion DistortionEffect
             {
               get
@@ -97,6 +99,10 @@ namespace OSVR
                 {
                     clientKit = GameObject.FindObjectOfType<ClientKit>();
                 }
+                if (head == null)
+                {
+                    gameObject.GetComponentInParent<VRHead>();
+                }
                 //cache:
                 cachedTransform = transform;
 
@@ -136,6 +142,10 @@ namespace OSVR
             void OnPreRender()
             {
                 clientKit.context.update();
+                if (head)
+                {
+                    head.UpdatePose();
+                }
             }
             #endregion
 

--- a/OSVR-Unity/Assets/OSVRUnity/src/VRHead.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRHead.cs
@@ -55,6 +55,7 @@ namespace OSVR
             private DeviceDescriptor _deviceDescriptor;
             private DisplayInterface _displayInterface;
             private bool _initDisplayInterface = false;
+            private PoseInterface _poseIf;
             #endregion
 
             #region Init
@@ -69,6 +70,7 @@ namespace OSVR
                 }
 */
                 _displayInterface = GetComponent<DisplayInterface>();
+                _poseIf = GetComponent<PoseInterface>();
 
                 //update VRHead with info from the display interface if it has been initialized
                 //it might not be initialized if it is still parsing a display json file
@@ -102,6 +104,12 @@ namespace OSVR
                     UpdateStereoAmount();
                     UpdateViewMode();
                 }
+            }
+            public void UpdatePose()
+            {
+                var state = _poseIf.Interface.GetState();
+                transform.localPosition = state.Value.Position;
+                transform.localRotation = state.Value.Rotation;
             }
             #endregion
 
@@ -165,6 +173,8 @@ namespace OSVR
                     switch (currentEye.eye)
                     {
                         case Eye.left:
+                            // Only need one eye to update the head.
+                            currentEye.head = this;
                             _leftEye = currentEye;
                             break;
 


### PR DESCRIPTION
Changed the extra call to client kit update to be in on pre render, not on post render - no point in having an extra update on post render. Also, actually update the transform of the head in onprerender, which should use the latest data available, will make a difference if any data came in between Update and OnPreRender.