### PR TITLE
Only call SetResolution if we have an HMD with more than one video input

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -243,9 +243,13 @@ namespace OSVR
                 }
 
                 //Set the resolution. Don't force fullscreen if we have multiple display inputs
-                Screen.SetResolution((int)TotalDisplayWidth, (int)TotalDisplayHeight, numDisplayInputs < 2);
+                //@todo figure out why this causes problems with direct mode, perhaps overfill factor?
+                if(numDisplayInputs > 1)
+                {
+                    Screen.SetResolution((int)TotalDisplayWidth, (int)TotalDisplayHeight, false);
+                }                             
+                
             }
-
 
             // Creates a head and eyes as configured in clientKit
             // Viewers and Eyes are siblings, children of DisplayController


### PR DESCRIPTION
This was causing DirectMode to fail only in an executable. This is probably a temporary fix that will work for 1-input HMDs. Have not yet tested this on an HMD with 2 inputs. The issue could be due to render overfill factor.