### PR TITLE
Only set resolution if we're not in DirectMode.

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -243,8 +243,9 @@ namespace OSVR
                 }
 
                 //Set the resolution. Don't force fullscreen if we have multiple display inputs
+                //We only need to do this if we aren't using RenderManager, because it adjusts the window size for us
                 //@todo figure out why this causes problems with direct mode, perhaps overfill factor?
-                if(numDisplayInputs > 1)
+                if(numDisplayInputs > 1 && !UseRenderManager)
                 {
                     Screen.SetResolution((int)TotalDisplayWidth, (int)TotalDisplayHeight, false);
                 }                             


### PR DESCRIPTION
This should open path for DirectMode on 2-video input HMDs without running into the SetResolution bug.