### PR TITLE
detect existing VRViewer in scene.

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/Prefabs/VRDisplayTracked.prefab
+++ b/OSVR-Unity/Assets/OSVRUnity/Prefabs/VRDisplayTracked.prefab
@@ -74,7 +74,7 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: .300000012
+  near clip plane: .100000001
   far clip plane: 1000
   field of view: 60
   orthographic: 0

--- a/OSVR-Unity/Assets/OSVRUnity/Prefabs/VRDisplayTracked.prefab
+++ b/OSVR-Unity/Assets/OSVRUnity/Prefabs/VRDisplayTracked.prefab
@@ -12,7 +12,7 @@ GameObject:
   - 114: {fileID: 11400508}
   m_Layer: 0
   m_Name: VRViewer0
-  m_TagString: Untagged
+  m_TagString: MainCamera
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -28,7 +28,7 @@ GameObject:
   - 114: {fileID: 11463916}
   m_Layer: 0
   m_Name: VRDisplayTracked
-  m_TagString: MainCamera
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/OSVR-Unity/Assets/OSVRUnity/Prefabs/VRDisplayTracked.prefab
+++ b/OSVR-Unity/Assets/OSVRUnity/Prefabs/VRDisplayTracked.prefab
@@ -1,5 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100508
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 400508}
+  - 20: {fileID: 2000508}
+  - 114: {fileID: 11400508}
+  m_Layer: 0
+  m_Name: VRViewer0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &131736
 GameObject:
   m_ObjectHideFlags: 0
@@ -8,7 +25,6 @@ GameObject:
   serializedVersion: 4
   m_Component:
   - 4: {fileID: 431736}
-  - 20: {fileID: 2065472}
   - 114: {fileID: 11463916}
   m_Layer: 0
   m_Name: VRDisplayTracked
@@ -17,6 +33,18 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!4 &400508
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100508}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 431736}
+  m_RootOrder: 0
 --- !u!4 &431736
 Transform:
   m_ObjectHideFlags: 1
@@ -26,15 +54,16 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 400508}
   m_Father: {fileID: 0}
   m_RootOrder: 0
---- !u!20 &2065472
+--- !u!20 &2000508
 Camera:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 131736}
+  m_GameObject: {fileID: 100508}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
@@ -45,7 +74,7 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: .00999999978
+  near clip plane: .300000012
   far clip plane: 1000
   field of view: 60
   orthographic: 0
@@ -61,6 +90,18 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: .0219999999
+--- !u!114 &11400508
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100508}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 425e251a3200841b98a61cd7234fc119, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cachedTransform: {fileID: 0}
 --- !u!114 &11463916
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -72,6 +113,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c2b982789045b4641a4c4898908314b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  showDirectModePreview: 1
 --- !u!1001 &100100000
 Prefab:
   m_ObjectHideFlags: 1

--- a/OSVR-Unity/Assets/OSVRUnity/Prefabs/VRFirstPersonController.prefab
+++ b/OSVR-Unity/Assets/OSVRUnity/Prefabs/VRFirstPersonController.prefab
@@ -1,22 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &163456
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
-  m_Component:
-  - 4: {fileID: 463456}
-  - 20: {fileID: 2063460}
-  - 114: {fileID: 11463454}
-  m_Layer: 0
-  m_Name: VRDisplayTracked
-  m_TagString: MainCamera
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &163458
 GameObject:
   m_ObjectHideFlags: 0
@@ -53,18 +36,39 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 0
---- !u!4 &463456
-Transform:
+--- !u!1 &164270
+GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 163456}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: .0799999237, y: .449999928, z: .240999937}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 463458}
-  m_RootOrder: 1
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 464270}
+  - 20: {fileID: 2064272}
+  - 114: {fileID: 11464270}
+  m_Layer: 0
+  m_Name: VRViewer0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &164272
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 464272}
+  - 114: {fileID: 11464272}
+  m_Layer: 0
+  m_Name: VRDisplayTracked
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!4 &463458
 Transform:
   m_ObjectHideFlags: 1
@@ -76,7 +80,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 463460}
-  - {fileID: 463456}
+  - {fileID: 464272}
   m_Father: {fileID: 0}
   m_RootOrder: 0
 --- !u!4 &463460
@@ -91,12 +95,37 @@ Transform:
   m_Children: []
   m_Father: {fileID: 463458}
   m_RootOrder: 0
---- !u!20 &2063460
+--- !u!4 &464270
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 164270}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 464272}
+  m_RootOrder: 0
+--- !u!4 &464272
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 164272}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: .0799999237, y: .449999928, z: .240999937}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 464270}
+  m_Father: {fileID: 463458}
+  m_RootOrder: 1
+--- !u!20 &2064272
 Camera:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 163456}
+  m_GameObject: {fileID: 164270}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
@@ -107,7 +136,7 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: .00999999978
+  near clip plane: .300000012
   far clip plane: 1000
   field of view: 60
   orthographic: 0
@@ -150,17 +179,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 163460}
   m_Mesh: {fileID: 10205, guid: 0000000000000000e000000000000000, type: 0}
---- !u!114 &11463454
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 163456}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c2b982789045b4641a4c4898908314b3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &11463456
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -239,6 +257,30 @@ MonoBehaviour:
     extraHeight: 4.0999999
     perpAmount: 0
     steepPerpAmount: .5
+--- !u!114 &11464270
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 164270}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 425e251a3200841b98a61cd7234fc119, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cachedTransform: {fileID: 0}
+--- !u!114 &11464272
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 164272}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c2b982789045b4641a4c4898908314b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  showDirectModePreview: 1
 --- !u!143 &14363460
 CharacterController:
   m_ObjectHideFlags: 1

--- a/OSVR-Unity/Assets/OSVRUnity/Prefabs/VRFirstPersonController.prefab
+++ b/OSVR-Unity/Assets/OSVRUnity/Prefabs/VRFirstPersonController.prefab
@@ -136,7 +136,7 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: .300000012
+  near clip plane: .100000001
   far clip plane: 1000
   field of view: 60
   orthographic: 0

--- a/OSVR-Unity/Assets/OSVRUnity/Prefabs/VRFirstPersonController.prefab
+++ b/OSVR-Unity/Assets/OSVRUnity/Prefabs/VRFirstPersonController.prefab
@@ -48,7 +48,7 @@ GameObject:
   - 114: {fileID: 11464270}
   m_Layer: 0
   m_Name: VRViewer0
-  m_TagString: Untagged
+  m_TagString: MainCamera
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/OSVR-Unity/Assets/OSVRUnity/Sample/Demo/Scenes/OSVRDemo2.unity
+++ b/OSVR-Unity/Assets/OSVRUnity/Sample/Demo/Scenes/OSVRDemo2.unity
@@ -237,7 +237,6 @@ GameObject:
   serializedVersion: 4
   m_Component:
   - 4: {fileID: 75519521}
-  - 20: {fileID: 75519520}
   - 114: {fileID: 75519519}
   m_Layer: 0
   m_Name: VRDisplayTracked
@@ -258,13 +257,69 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c2b982789045b4641a4c4898908314b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!20 &75519520
-Camera:
+  showDirectModePreview: 1
+--- !u!4 &75519521
+Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 2065472, guid: bcbb49b5078d05d498ef83a6373ba939,
-    type: 2}
+  m_PrefabParentObject: {fileID: 431736, guid: bcbb49b5078d05d498ef83a6373ba939, type: 2}
   m_PrefabInternal: {fileID: 1231217840}
   m_GameObject: {fileID: 75519518}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 154952065}
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+--- !u!1 &154952064
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 100508, guid: bcbb49b5078d05d498ef83a6373ba939, type: 2}
+  m_PrefabInternal: {fileID: 1231217840}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 154952065}
+  - 20: {fileID: 154952067}
+  - 114: {fileID: 154952066}
+  m_Layer: 0
+  m_Name: VRViewer0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &154952065
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 400508, guid: bcbb49b5078d05d498ef83a6373ba939, type: 2}
+  m_PrefabInternal: {fileID: 1231217840}
+  m_GameObject: {fileID: 154952064}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 75519521}
+  m_RootOrder: 0
+--- !u!114 &154952066
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 11400508, guid: bcbb49b5078d05d498ef83a6373ba939,
+    type: 2}
+  m_PrefabInternal: {fileID: 1231217840}
+  m_GameObject: {fileID: 154952064}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 425e251a3200841b98a61cd7234fc119, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cachedTransform: {fileID: 0}
+--- !u!20 &154952067
+Camera:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 2000508, guid: bcbb49b5078d05d498ef83a6373ba939,
+    type: 2}
+  m_PrefabInternal: {fileID: 1231217840}
+  m_GameObject: {fileID: 154952064}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
@@ -275,7 +330,7 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: .00999999978
+  near clip plane: .300000012
   far clip plane: 1000
   field of view: 60
   orthographic: 0
@@ -291,18 +346,6 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: .0219999999
---- !u!4 &75519521
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 431736, guid: bcbb49b5078d05d498ef83a6373ba939, type: 2}
-  m_PrefabInternal: {fileID: 1231217840}
-  m_GameObject: {fileID: 75519518}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 1
 --- !u!1 &221478720
 GameObject:
   m_ObjectHideFlags: 0

--- a/OSVR-Unity/Assets/OSVRUnity/Sample/Demo/Scenes/OSVRDemo2.unity
+++ b/OSVR-Unity/Assets/OSVRUnity/Sample/Demo/Scenes/OSVRDemo2.unity
@@ -240,7 +240,7 @@ GameObject:
   - 114: {fileID: 75519519}
   m_Layer: 0
   m_Name: VRDisplayTracked
-  m_TagString: MainCamera
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -283,7 +283,7 @@ GameObject:
   - 114: {fileID: 154952066}
   m_Layer: 0
   m_Name: VRViewer0
-  m_TagString: Untagged
+  m_TagString: MainCamera
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/OSVR-Unity/Assets/OSVRUnity/Sample/Demo/Scenes/OSVRDemo2.unity
+++ b/OSVR-Unity/Assets/OSVRUnity/Sample/Demo/Scenes/OSVRDemo2.unity
@@ -330,7 +330,7 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: .300000012
+  near clip plane: .100000001
   far clip plane: 1000
   field of view: 60
   orthographic: 0
@@ -1854,6 +1854,10 @@ Prefab:
     - target: {fileID: 431736, guid: bcbb49b5078d05d498ef83a6373ba939, type: 2}
       propertyPath: m_RootOrder
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2000508, guid: bcbb49b5078d05d498ef83a6373ba939, type: 2}
+      propertyPath: near clip plane
+      value: .100000001
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: bcbb49b5078d05d498ef83a6373ba939, type: 2}

--- a/OSVR-Unity/Assets/OSVRUnity/Sample/VRFirstPerson.unity
+++ b/OSVR-Unity/Assets/OSVRUnity/Sample/VRFirstPerson.unity
@@ -75,6 +75,81 @@ NavMeshSettings:
     heightInaccuracy: 10
     tileSizeHint: 0
   m_NavMesh: {fileID: 0}
+--- !u!1 &124327598
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 164270, guid: ff42ecd8706e4d6478ce74033f2f16b5, type: 2}
+  m_PrefabInternal: {fileID: 853150949}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 124327601}
+  - 20: {fileID: 124327600}
+  - 114: {fileID: 124327599}
+  m_Layer: 0
+  m_Name: VRViewer0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &124327599
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 11464270, guid: ff42ecd8706e4d6478ce74033f2f16b5,
+    type: 2}
+  m_PrefabInternal: {fileID: 853150949}
+  m_GameObject: {fileID: 124327598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 425e251a3200841b98a61cd7234fc119, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cachedTransform: {fileID: 0}
+--- !u!20 &124327600
+Camera:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 2064272, guid: ff42ecd8706e4d6478ce74033f2f16b5,
+    type: 2}
+  m_PrefabInternal: {fileID: 853150949}
+  m_GameObject: {fileID: 124327598}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: .192156866, g: .301960796, b: .474509805, a: .0196078438}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: .300000012
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_HDR: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: .0219999999
+--- !u!4 &124327601
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 464270, guid: ff42ecd8706e4d6478ce74033f2f16b5, type: 2}
+  m_PrefabInternal: {fileID: 853150949}
+  m_GameObject: {fileID: 124327598}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1458956041}
+  m_RootOrder: 0
 --- !u!1001 &853150949
 Prefab:
   m_ObjectHideFlags: 0
@@ -523,6 +598,48 @@ MeshFilter:
   m_PrefabInternal: {fileID: 853150949}
   m_GameObject: {fileID: 1427207309}
   m_Mesh: {fileID: 10205, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1458956040
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 164272, guid: ff42ecd8706e4d6478ce74033f2f16b5, type: 2}
+  m_PrefabInternal: {fileID: 853150949}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1458956041}
+  - 114: {fileID: 1458956042}
+  m_Layer: 0
+  m_Name: VRDisplayTracked
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1458956041
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 464272, guid: ff42ecd8706e4d6478ce74033f2f16b5, type: 2}
+  m_PrefabInternal: {fileID: 853150949}
+  m_GameObject: {fileID: 1458956040}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: .0799999237, y: .449999928, z: .240999937}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 124327601}
+  m_Father: {fileID: 1939124368}
+  m_RootOrder: 1
+--- !u!114 &1458956042
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 11464272, guid: ff42ecd8706e4d6478ce74033f2f16b5,
+    type: 2}
+  m_PrefabInternal: {fileID: 853150949}
+  m_GameObject: {fileID: 1458956040}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c2b982789045b4641a4c4898908314b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  showDirectModePreview: 1
 --- !u!1 &1721992120
 GameObject:
   m_ObjectHideFlags: 0
@@ -984,80 +1101,6 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1427207310}
-  - {fileID: 2102717111}
+  - {fileID: 1458956041}
   m_Father: {fileID: 0}
   m_RootOrder: 0
---- !u!1 &2102717110
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 163456, guid: ff42ecd8706e4d6478ce74033f2f16b5, type: 2}
-  m_PrefabInternal: {fileID: 853150949}
-  serializedVersion: 4
-  m_Component:
-  - 4: {fileID: 2102717111}
-  - 20: {fileID: 2102717113}
-  - 114: {fileID: 2102717112}
-  m_Layer: 0
-  m_Name: VRDisplayTracked
-  m_TagString: MainCamera
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2102717111
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 463456, guid: ff42ecd8706e4d6478ce74033f2f16b5, type: 2}
-  m_PrefabInternal: {fileID: 853150949}
-  m_GameObject: {fileID: 2102717110}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: .0799999237, y: .449999928, z: .240999937}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1939124368}
-  m_RootOrder: 1
---- !u!114 &2102717112
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 11463454, guid: ff42ecd8706e4d6478ce74033f2f16b5,
-    type: 2}
-  m_PrefabInternal: {fileID: 853150949}
-  m_GameObject: {fileID: 2102717110}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c2b982789045b4641a4c4898908314b3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!20 &2102717113
-Camera:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 2063460, guid: ff42ecd8706e4d6478ce74033f2f16b5,
-    type: 2}
-  m_PrefabInternal: {fileID: 853150949}
-  m_GameObject: {fileID: 2102717110}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 1
-  m_BackGroundColor: {r: .192156866, g: .301960796, b: .474509805, a: .0196078438}
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: .00999999978
-  far clip plane: 1000
-  field of view: 60
-  orthographic: 0
-  orthographic size: 5
-  m_Depth: 0
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_HDR: 0
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: .0219999999

--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -68,6 +68,7 @@ namespace OSVR
             public VRViewer[] Viewers { get { return _viewers; } }
             public uint ViewerCount { get { return _viewerCount; } }
             public OsvrRenderManager RenderManager { get { return _renderManager; } }
+            public bool showDirectModePreview = true; //should the monitor show what the user sees in the HMD?
 
             public uint TotalDisplayWidth
             {

--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -58,7 +58,7 @@ namespace OSVR
             //variables for controlling use of osvrUnityRenderingPlugin.dll which enables DirectMode
             private OsvrRenderManager _renderManager;
             private bool _useRenderManager = false; //requires Unity 5.2+ and RenderManager configured osvr server
-            public bool UseRenderManager { get { return _useRenderManager; } }
+            public bool UseRenderManager { get { return _useRenderManager; } set { _useRenderManager = value; } }
 
             public OSVR.ClientKit.DisplayConfig DisplayConfig
             {

--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -41,7 +41,6 @@ namespace OSVR
         //
         // In this implementation, we are assuming that there is exactly one viewer and one surface per eye.
         //*/
-        [RequireComponent(typeof(Camera))] //requires a "dummy" camera
         public class DisplayController : MonoBehaviour
         {
 
@@ -53,9 +52,6 @@ namespace OSVR
             private VRViewer[] _viewers;
             private uint _viewerCount;
             private bool _displayConfigInitialized = false;
-            private bool _checkDisplayStartup = false;
-            private Camera _camera;
-            private bool _disabledCamera = true;
             private uint _totalDisplayWidth;
             private uint _totalSurfaceHeight;
 
@@ -64,18 +60,6 @@ namespace OSVR
             private bool _useRenderManager = false; //requires Unity 5.2+ and RenderManager configured osvr server
             public bool UseRenderManager { get { return _useRenderManager; } }
 
-            public Camera Camera
-            {
-                get
-                {
-                    if (_camera == null)
-                    {
-                        _camera = GetComponent<Camera>();
-                    }
-                    return _camera;
-                }
-                set { _camera = value; }
-            }
             public OSVR.ClientKit.DisplayConfig DisplayConfig
             {
                 get { return _displayConfig; }

--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -102,23 +102,8 @@ namespace OSVR
                 {
                     Debug.LogError("DisplayController requires a ClientKit object in the scene.");
                 }
-                _camera = GetComponent<Camera>(); //get the "dummy" camera
+                
                 SetupApplicationSettings();
-
-            }
-
-            void OnEnable()
-            {
-                StartCoroutine("EndOfFrame");
-            }
-
-            void OnDisable()
-            {
-                StopCoroutine("EndOfFrame");
-                if (_useRenderManager && RenderManager != null)
-                {
-                    RenderManager.ExitRenderManager();
-                }
             }
 
             void SetupApplicationSettings()
@@ -207,7 +192,6 @@ namespace OSVR
 
                 //create scene objects 
                 CreateHeadAndEyes();
-                Camera.cullingMask = 0;
             }
 
             //Set Resolution of the Unity game window based on total surface width
@@ -285,82 +269,18 @@ namespace OSVR
                 _clientKit.context.update();
             }
 
-            // Culling determines which objects are visible to the camera. OnPreCull is called just before this process.
-            // This gets called because we have a camera component, but we disable the camera here so it doesn't render.
-            // We have the "dummy" camera so existing Unity game code can refer to a MainCamera object.
-            // We update our viewer and eye transforms here because it is as late as possible before rendering happens.
-            // OnPreRender is not called because we disable the camera here.
-            void OnPreCull()
+            public bool CheckDisplayStartup()
             {
-                // Disable dummy camera during rendering
-                // Enable after frame ends
-                _camera.enabled = false;
-
-                DoRendering();
-                if (!_checkDisplayStartup && _displayConfigInitialized)
-                {
-                    _checkDisplayStartup = DisplayConfig.CheckDisplayStartup();
-                }
-
-                // Flag that we disabled the camera
-                _disabledCamera = true;
+                return _displayConfigInitialized && DisplayConfig.CheckDisplayStartup();
             }
 
-            // The main rendering loop, should be called late in the pipeline, i.e. from OnPreCull
-            // Set our viewer and eye poses and render to each surface.
-            void DoRendering()
+            public void ExitRenderManager()
             {
-                // for each viewer, update each eye, which will update each surface
-                for (uint viewerIndex = 0; viewerIndex < _viewerCount; viewerIndex++)
+                if(UseRenderManager && RenderManager != null)
                 {
-                    VRViewer viewer = Viewers[viewerIndex];
-
-                    // update poses once DisplayConfig is ready
-                    if (_checkDisplayStartup)
-                    {
-                        // update the viewer's head pose
-                        // @todo Get viewer pose from RenderManager if UseRenderManager = true
-                        // currently getting viewer pose from DisplayConfig always
-                        viewer.UpdateViewerHeadPose(DisplayConfig.GetViewerPose(viewerIndex));
-
-                        // each viewer updates its eye poses, viewports, projection matrices
-                        viewer.UpdateEyes();
-                    }
-                    else
-                    {
-                        _checkDisplayStartup = DisplayConfig.CheckDisplayStartup();
-                        if (!_checkDisplayStartup)
-                        {
-                            Debug.LogError("Display Startup failed. Check HMD connection.");
-                        }
-                    }
-                }
-            }
-
-            // This couroutine is called every frame.
-            IEnumerator EndOfFrame()
-            {
-                while (true)
-                {
-                    //if we disabled the dummy camera, enable it here
-                    if (_disabledCamera)
-                    {
-                        Camera.enabled = true;
-                        _disabledCamera = false;
-                    }
-                    yield return new WaitForEndOfFrame();
-                    if (_useRenderManager && _checkDisplayStartup)
-                    {
-                        // Issue a RenderEvent, which copies Unity RenderTextures to RenderManager buffers
-#if UNITY_5_2 || UNITY_5_3
-                        GL.IssuePluginEvent(_renderManager.GetRenderEventFunction(), OsvrRenderManager.RENDER_EVENT);
-#else
-                        Debug.LogError("GL.IssuePluginEvent failed. This version of Unity is not supported by RenderManager.");
-#endif
-                    }
-
-                }
-            }
+                    RenderManager.ExitRenderManager();
+                }             
+            }         
         }
     }
 }

--- a/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
@@ -83,7 +83,9 @@ namespace OSVR
             public void UpdateEyePose(OSVR.ClientKit.Pose3 eyePose)
             { 
                 cachedTransform.localPosition = Math.ConvertPosition(eyePose.translation);
-                cachedTransform.localRotation = Viewer.DisplayController.UseRenderManager ? Math.ConvertOrientationFromRenderManager(eyePose.rotation) : Math.ConvertOrientation(eyePose.rotation);
+                //cachedTransform.localRotation = Viewer.DisplayController.UseRenderManager ? Math.ConvertOrientationFromRenderManager(eyePose.rotation) : Math.ConvertOrientation(eyePose.rotation);
+                //@todo use DisplayConfig path until RenderManager EyePose bug is fixed
+                cachedTransform.localRotation = Math.ConvertOrientation(eyePose.rotation);
             }
 
             //For each Surface, update viewing parameters and render the surface

--- a/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
@@ -173,7 +173,7 @@ namespace OSVR
                     VRSurface surface = surfaceGameObject.AddComponent<VRSurface>();
                     surface.Eye = this;
                     surface.Camera = surfaceGameObject.GetComponent<Camera>(); //VRSurface has camera component by default
-                    CopyCamera(Viewer.DisplayController.Camera, surface.Camera); //copy camera properties from the "dummy" camera to surface camera
+                    CopyCamera(Viewer.Camera, surface.Camera); //copy camera properties from the "dummy" camera to surface camera
                     surface.Camera.enabled = !Viewer.DisplayController.UseRenderManager; //disabled so we can control rendering manually
                     surfaceGameObject.transform.parent = this.transform; //surface is child of Eye
                     surfaceGameObject.transform.localPosition = Vector3.zero;

--- a/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
@@ -24,7 +24,8 @@ using System.Collections;
 namespace OSVR
 {
     namespace Unity
-    {       
+    {
+        [RequireComponent(typeof(Camera))]  
         public class VRViewer : MonoBehaviour
         {   
             #region Public Variables         
@@ -34,6 +35,18 @@ namespace OSVR
             public uint ViewerIndex { get { return _viewerIndex; } set { _viewerIndex = value; } }
             [HideInInspector]
             public Transform cachedTransform;
+            public Camera Camera
+            {
+                get
+                {
+                    if (_camera == null)
+                    {
+                        _camera = GetComponent<Camera>();
+                    }
+                    return _camera;
+                }
+                set { _camera = value; }
+            }
             #endregion
 
             #region Private Variables
@@ -41,6 +54,9 @@ namespace OSVR
             private VREye[] _eyes;
             private uint _eyeCount;
             private uint _viewerIndex;
+            private Camera _camera;
+            private bool _disabledCamera = true;
+            
 
             #endregion
 
@@ -53,6 +69,20 @@ namespace OSVR
             {
                 //cache:
                 cachedTransform = transform;
+            }
+
+            void OnEnable()
+            {
+                StartCoroutine("EndOfFrame");
+            }
+
+            void OnDisable()
+            {
+                StopCoroutine("EndOfFrame");
+                if (DisplayController.UseRenderManager && DisplayController.RenderManager != null)
+                {
+                    DisplayController.ExitRenderManager();
+                }
             }
 
             //Creates the Eyes of this Viewer
@@ -72,7 +102,13 @@ namespace OSVR
                     uint eyeSurfaceCount = DisplayController.DisplayConfig.GetNumSurfacesForViewerEye(ViewerIndex, (byte)eyeIndex);
                     eye.CreateSurfaces(eyeSurfaceCount);
                 }
-            }  
+            }
+
+            //Get an updated tracker position + orientation
+            public OSVR.ClientKit.Pose3 GetViewerPose(uint viewerIndex)
+            {
+                return DisplayController.DisplayConfig.GetViewerPose(viewerIndex);
+            }
 
             //Updates the position and rotation of the head
             public void UpdateViewerHeadPose(OSVR.ClientKit.Pose3 headPose)
@@ -117,7 +153,92 @@ namespace OSVR
                     // update the eye's surfaces, includes call to Render
                     eye.UpdateSurfaces();                   
                 }
-            }                  
+            }
+
+            //helper method for updating the client context
+            public void UpdateClient()
+            {
+                DisplayController.UpdateClient();
+            }
+
+            // Culling determines which objects are visible to the camera. OnPreCull is called just before this process.
+            // This gets called because we have a camera component, but we disable the camera here so it doesn't render.
+            // We have the "dummy" camera so existing Unity game code can refer to a MainCamera object.
+            // We update our viewer and eye transforms here because it is as late as possible before rendering happens.
+            // OnPreRender is not called because we disable the camera here.
+            void OnPreCull()
+            {
+                
+                if(!DisplayController.CheckDisplayStartup())
+                {
+                    //leave this preview camera enabled if there is no display config
+                    _camera.enabled = true;
+                }
+                else
+                {
+                    // To save Render time, disable this camera here and re-enable after the frame
+                    // OR, in DirectMode, leave it on for "mirror" mode, although this is an expensive operation
+                    // The long-term solution is to provide a DirectMode preview window in RenderManager
+                    //@todo enable directmode preview in RenderManager
+                    _camera.enabled = DisplayController.UseRenderManager && DisplayController.showDirectModePreview;
+                }
+
+                DoRendering();
+
+                // Flag that we disabled the camera
+                _disabledCamera = true;
+            }
+
+            // The main rendering loop, should be called late in the pipeline, i.e. from OnPreCull
+            // Set our viewer and eye poses and render to each surface.
+            void DoRendering()
+            {
+                // update poses once DisplayConfig is ready
+                if (DisplayController.CheckDisplayStartup())
+                {
+                    // update the viewer's head pose
+                    // @todo Get viewer pose from RenderManager if UseRenderManager = true
+                    // currently getting viewer pose from DisplayConfig always
+                    UpdateViewerHeadPose(GetViewerPose(ViewerIndex));
+
+                    // each viewer updates its eye poses, viewports, projection matrices
+                    UpdateEyes();
+
+                }
+                else
+                {
+                    if (!DisplayController.CheckDisplayStartup())
+                    {
+                        //@todo do something other than not show anything
+                        Debug.LogError("Display Startup failed. Check HMD connection.");
+                    }
+                }
+            }
+
+            // This couroutine is called every frame.
+            IEnumerator EndOfFrame()
+            {
+                while (true)
+                {
+                    //if we disabled the dummy camera, enable it here
+                    if (_disabledCamera)
+                    {
+                        Camera.enabled = true;
+                        _disabledCamera = false;
+                    }
+                    yield return new WaitForEndOfFrame();
+                    if (DisplayController.UseRenderManager && DisplayController.CheckDisplayStartup())
+                    {
+                        // Issue a RenderEvent, which copies Unity RenderTextures to RenderManager buffers
+#if UNITY_5_2 || UNITY_5_3
+                        GL.IssuePluginEvent(DisplayController.RenderManager.GetRenderEventFunction(), OsvrRenderManager.RENDER_EVENT);
+#else
+                        Debug.LogError("GL.IssuePluginEvent failed. This version of Unity is not supported by RenderManager.");
+#endif
+                    }
+
+                }
+            }             
         }
     }
 }

--- a/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
@@ -144,7 +144,10 @@ namespace OSVR
                 {                   
                     //update the eye pose
                     VREye eye = Eyes[eyeIndex];
-                    if (DisplayController.UseRenderManager)
+                    //get eye pose from DisplayConfig
+                    //@todo fix bug with poses coming from RenderManager
+                    eye.UpdateEyePose(_displayController.DisplayConfig.GetViewerEyePose(ViewerIndex, (byte)eyeIndex));
+                    /*if (DisplayController.UseRenderManager)
                     { 
                         //get eye pose from RenderManager                     
                         eye.UpdateEyePose(DisplayController.RenderManager.GetRenderManagerEyePose((byte)eyeIndex));
@@ -153,7 +156,7 @@ namespace OSVR
                     {
                         //get eye pose from DisplayConfig
                         eye.UpdateEyePose(_displayController.DisplayConfig.GetViewerEyePose(ViewerIndex, (byte)eyeIndex));
-                    }
+                    }*/
                         
 
                     // update the eye's surfaces, includes call to Render

--- a/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
@@ -67,8 +67,13 @@ namespace OSVR
 
             void Init()
             {
+                _camera = GetComponent<Camera>();
                 //cache:
                 cachedTransform = transform;
+                if (DisplayController == null)
+                {
+                    DisplayController = FindObjectOfType<DisplayController>();
+                }
             }
 
             void OnEnable()

--- a/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
@@ -131,7 +131,8 @@ namespace OSVR
 #if UNITY_5_2 || UNITY_5_3
                     GL.IssuePluginEvent(DisplayController.RenderManager.GetRenderEventFunction(), OsvrRenderManager.UPDATE_RENDERINFO_EVENT);
 #else
-                    Debug.LogError("GL.IssuePluginEvent failed. This version of Unity is not supported by RenderManager.");
+                    Debug.LogError("GL.IssuePluginEvent failed. This version of Unity cannot support RenderManager.");
+                    DisplayController.UseRenderManager = false;
 #endif
                 }
                 else
@@ -238,7 +239,8 @@ namespace OSVR
 #if UNITY_5_2 || UNITY_5_3
                         GL.IssuePluginEvent(DisplayController.RenderManager.GetRenderEventFunction(), OsvrRenderManager.RENDER_EVENT);
 #else
-                        Debug.LogError("GL.IssuePluginEvent failed. This version of Unity is not supported by RenderManager.");
+                        Debug.LogError("GL.IssuePluginEvent failed. This version of Unity cannot support RenderManager.");
+                        DisplayController.UseRenderManager = false;
 #endif
                     }
 


### PR DESCRIPTION
This PR moves the main rendering loop from DisplayController to VRViewer. The biggest change is that a VRViewer with a camera (tagged "MainCamera") now exists in the scene before runtime (but doesn't have to). This plays nicely with Unity's VR setup, as Unity VR projects will always have a MainCamera in the scene, likely referenced by other objects in the scene. A Unity VR scene can be converted to an OSVR-Unity VR scene simply by adding a VRViewer component to the MainCamera, without breaking existing references.

Changes here also include the ill-advised, expensive "DirectMode Preview" by way of leaving the VRViewer camera on during rendering. If performance suffers in DirectMode, the first optimization to make is turning this option off. It is configurable via a boolean in the editor on the DisplayController component.

These changes are the result of integrating OSVR into Unity's new VR Samples project. They are designed to make turning a Unity VR project into an OSVR-Unity VR project as simple as possible.