### PR TITLE
Set RenderManager RenderParams

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -194,7 +194,6 @@ namespace OSVR
                 //create scene objects 
                 CreateHeadAndEyes();
                 SetRenderParams();
-                Camera.cullingMask = 0;
             }
 
             //Set RenderManager rendering parameters: near and far clip plane distance and IPD
@@ -204,7 +203,7 @@ namespace OSVR
                 {
                     RenderManager.SetNearClippingPlaneDistance(Camera.main.nearClipPlane);
                     RenderManager.SetFarClippingPlaneDistance(Camera.main.farClipPlane);
-                    //@todo set IPD as well
+                    //could set IPD as well
                 }
             }
 

--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -223,7 +223,19 @@ namespace OSVR
 
                 //create scene objects 
                 CreateHeadAndEyes();
+                SetRenderParams();
                 Camera.cullingMask = 0;
+            }
+
+            //Set RenderManager rendering parameters: near and far clip plane distance and IPD
+            private void SetRenderParams()
+            {
+                if (UseRenderManager && RenderManager != null)
+                {
+                    RenderManager.SetNearClippingPlaneDistance(Camera.main.nearClipPlane);
+                    RenderManager.SetFarClippingPlaneDistance(Camera.main.farClipPlane);
+                    //@todo set IPD as well
+                }
             }
 
             //Set Resolution of the Unity game window based on total surface width

--- a/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
@@ -61,6 +61,15 @@ namespace OSVR
             [DllImport(PluginName, CallingConvention = CallingConvention.Cdecl)]
             private static extern void SetColorBufferFromUnity(System.IntPtr texturePtr, int eye);
 
+            [DllImport(PluginName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern void SetNearClipDistance(double nearClipPlaneDistance);
+
+            [DllImport(PluginName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern void SetFarClipDistance(double farClipPlaneDistance);
+
+            [DllImport(PluginName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern void SetIPD(double ipdMeters);
+
             //Create a RenderManager object in the plugin, passing in a ClientContext
             [DllImport(PluginName, CallingConvention = CallingConvention.Cdecl)]
             private static extern Byte CreateRenderManagerFromUnity(OSVR.ClientKit.SafeClientContextHandle /*OSVR_ClientContext*/ ctx);
@@ -113,6 +122,21 @@ namespace OSVR
                 //create a client context for RenderManager. This context should not be updated from Unity.
                 _renderManagerClientContext = new OSVR.ClientKit.ClientContext("com.sensics.rendermanagercontext", 0);
                 return CreateRenderManager(_renderManagerClientContext);
+            }
+
+            public void SetNearClippingPlaneDistance(float near)
+            {
+                SetNearClipDistance((double)near);
+            }
+
+            public void SetFarClippingPlaneDistance(float far)
+            {
+                SetFarClipDistance((double)far);
+            }
+
+            public void SetIPDMeters(float ipd)
+            {
+                SetIPD((double)ipd);
             }
 
             //Get the pose of a given eye from RenderManager


### PR DESCRIPTION
This PR adds functions for setting near and far clipping plane distances and IPD in RenderManager. The near and far clipping planes are copied from the MainCamera in the scene.
The IPD is not being set from Unity code, but the functionality is there to pass to RenderManager... can remove this if the IPD value should come from a config file.