### PR TITLE
Remove duplicate surface.Render()

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
@@ -108,6 +108,9 @@ namespace OSVR
 
                         //get projection matrix from RenderManager and set surface projection matrix
                         surface.SetProjectionMatrix(Viewer.DisplayController.RenderManager.GetEyeProjectionMatrix((int)EyeIndex));
+                   
+                        surface.Render();
+                        surface.SetActiveRenderTexture();
                     }
                     else
                     {
@@ -131,15 +134,6 @@ namespace OSVR
                         surface.Render();
                     }                           
 
-                    if(Viewer.DisplayController.UseRenderManager)
-                    {
-                        surface.Render();
-                        surface.SetActiveRenderTexture();
-                    }
-                    else
-                    {
-                        surface.Render();
-                    }
                 }
             }
 


### PR DESCRIPTION
The same if statement was repeated twice. In the case of usRenderManager being false, this led to surface.Render() being called twice and degrading performance.