### PR TITLE
Rendermanager recenter

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/Prefabs/Recenter.prefab
+++ b/OSVR-Unity/Assets/OSVRUnity/Prefabs/Recenter.prefab
@@ -1,0 +1,55 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &164708
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 464708}
+  - 114: {fileID: 11464708}
+  m_Layer: 0
+  m_Name: Recenter
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &464708
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 164708}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!114 &11464708
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 164708}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15db670fa9334634fb4ac475681e29e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  setRoomRotationKey: 114
+  clearRoomRotationKey: 117
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 164708}
+  m_IsPrefabParent: 1
+  m_IsExploded: 1

--- a/OSVR-Unity/Assets/OSVRUnity/Prefabs/Recenter.prefab.meta
+++ b/OSVR-Unity/Assets/OSVRUnity/Prefabs/Recenter.prefab.meta
@@ -1,0 +1,4 @@
+fileFormatVersion: 2
+guid: 6bf8080369c24bd42aa211819c0adda4
+NativeFormatImporter:
+  userData: 

--- a/OSVR-Unity/Assets/OSVRUnity/Sample/Scripts/SetRoomRotationUsingHead.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/Sample/Scripts/SetRoomRotationUsingHead.cs
@@ -1,0 +1,71 @@
+﻿/// OSVR-Unity
+///
+/// http://sensics.com/osvr
+///
+/// <copyright>
+/// Copyright 2016 Sensics, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+/// </copyright>
+
+using UnityEngine;
+using System.Collections;
+
+namespace OSVR
+{
+    namespace Unity
+    {
+
+        public class SetRoomRotationUsingHead : MonoBehaviour
+        {
+            public KeyCode setRoomRotationKey = KeyCode.R;
+            public KeyCode clearRoomRotationKey = KeyCode.U;
+            private ClientKit _clientKit;
+            private DisplayController _displayController;
+
+            void Awake()
+            {
+                _clientKit = FindObjectOfType<ClientKit>();
+                _displayController = FindObjectOfType<DisplayController>();
+            }
+
+            void FixedUpdate()
+            {
+                if (Input.GetKeyDown(setRoomRotationKey))
+                {                   
+                    
+                    if (_displayController != null && _displayController.UseRenderManager)
+                    {
+                        _displayController.RenderManager.SetRoomRotationUsingHead();
+                    }
+                    else
+                    {
+                        _clientKit.context.SetRoomRotationUsingHead();
+                    }
+                }
+                if (Input.GetKeyDown(clearRoomRotationKey))
+                {
+                    if (_displayController != null && _displayController.UseRenderManager)
+                    {
+                        _displayController.RenderManager.ClearRoomToWorldTransform();
+                    }
+                    else
+                    {
+                        _clientKit.context.ClearRoomToWorldTransform();
+                    }
+
+                }
+            }
+        }
+    }
+}

--- a/OSVR-Unity/Assets/OSVRUnity/Sample/Scripts/SetRoomRotationUsingHead.cs.meta
+++ b/OSVR-Unity/Assets/OSVRUnity/Sample/Scripts/SetRoomRotationUsingHead.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 15db670fa9334634fb4ac475681e29e3
+timeCreated: 1451925463
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OSVR-Unity/Assets/OSVRUnity/Sample/VRFirstPerson.unity
+++ b/OSVR-Unity/Assets/OSVRUnity/Sample/VRFirstPerson.unity
@@ -543,8 +543,8 @@ Transform:
 --- !u!1 &1253486346
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabParentObject: {fileID: 164708, guid: 6bf8080369c24bd42aa211819c0adda4, type: 2}
+  m_PrefabInternal: {fileID: 2011634246}
   serializedVersion: 4
   m_Component:
   - 4: {fileID: 1253486348}
@@ -559,8 +559,9 @@ GameObject:
 --- !u!114 &1253486347
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabParentObject: {fileID: 11464708, guid: 6bf8080369c24bd42aa211819c0adda4,
+    type: 2}
+  m_PrefabInternal: {fileID: 2011634246}
   m_GameObject: {fileID: 1253486346}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -572,8 +573,8 @@ MonoBehaviour:
 --- !u!4 &1253486348
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabParentObject: {fileID: 464708, guid: 6bf8080369c24bd42aa211819c0adda4, type: 2}
+  m_PrefabInternal: {fileID: 2011634246}
   m_GameObject: {fileID: 1253486346}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -1145,3 +1146,47 @@ Transform:
   - {fileID: 1458956041}
   m_Father: {fileID: 0}
   m_RootOrder: 0
+--- !u!1001 &2011634246
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 464708, guid: 6bf8080369c24bd42aa211819c0adda4, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464708, guid: 6bf8080369c24bd42aa211819c0adda4, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464708, guid: 6bf8080369c24bd42aa211819c0adda4, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464708, guid: 6bf8080369c24bd42aa211819c0adda4, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464708, guid: 6bf8080369c24bd42aa211819c0adda4, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464708, guid: 6bf8080369c24bd42aa211819c0adda4, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464708, guid: 6bf8080369c24bd42aa211819c0adda4, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 464708, guid: 6bf8080369c24bd42aa211819c0adda4, type: 2}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 6bf8080369c24bd42aa211819c0adda4, type: 2}
+  m_RootGameObject: {fileID: 1253486346}
+  m_IsPrefabParent: 0
+  m_IsExploded: 1

--- a/OSVR-Unity/Assets/OSVRUnity/Sample/VRFirstPerson.unity
+++ b/OSVR-Unity/Assets/OSVRUnity/Sample/VRFirstPerson.unity
@@ -87,7 +87,7 @@ GameObject:
   - 114: {fileID: 124327599}
   m_Layer: 0
   m_Name: VRViewer0
-  m_TagString: Untagged
+  m_TagString: MainCamera
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -122,7 +122,7 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: .300000012
+  near clip plane: .100000001
   far clip plane: 1000
   field of view: 60
   orthographic: 0
@@ -540,6 +540,47 @@ Transform:
   - {fileID: 877530638}
   m_Father: {fileID: 0}
   m_RootOrder: 2
+--- !u!1 &1253486346
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1253486348}
+  - 114: {fileID: 1253486347}
+  m_Layer: 0
+  m_Name: Recenter
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1253486347
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1253486346}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15db670fa9334634fb4ac475681e29e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  setRoomRotationKey: 114
+  clearRoomRotationKey: 117
+--- !u!4 &1253486348
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1253486346}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
 --- !u!1 &1427207309
 GameObject:
   m_ObjectHideFlags: 0

--- a/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
@@ -108,6 +108,7 @@ namespace OSVR
             private static extern void ShutdownRenderManager();
 
             private OSVR.ClientKit.ClientContext _renderManagerClientContext;
+            private ClientKit _clientKit;
             private bool _linkDebug = false; //causes crash on exit if true, only enable for debugging
 
             //Initialize use of RenderManager via CreateRenderManager call
@@ -119,6 +120,7 @@ namespace OSVR
                     //only use for debugging purposes, do not leave on for release.
                     LinkDebug(functionPointer); // Hook our c++ plugin into Unity's console log.
                 }
+                _clientKit = FindObjectOfType<ClientKit>();
                 //create a client context for RenderManager. This context should not be updated from Unity.
                 _renderManagerClientContext = new OSVR.ClientKit.ClientContext("com.sensics.rendermanagercontext", 0);
                 return CreateRenderManager(_renderManagerClientContext);
@@ -137,6 +139,24 @@ namespace OSVR
             public void SetIPDMeters(float ipd)
             {
                 SetIPD((double)ipd);
+            }
+
+            //"Recenter" based on current head orientation
+            public void SetRoomRotationUsingHead()
+            {
+#if UNITY_5_2 || UNITY_5_3
+                _clientKit.context.SetRoomRotationUsingHead();
+                GL.IssuePluginEvent(GetRenderEventFunc(), 3);
+#endif
+            }
+
+            //Clear the room-to-world transform, undo a call to SetRoomRotationUsingHead
+            public void ClearRoomToWorldTransform()
+            {
+#if UNITY_5_2 || UNITY_5_3
+                _clientKit.context.ClearRoomToWorldTransform();
+                GL.IssuePluginEvent(GetRenderEventFunc(), 4);
+#endif
             }
 
             //Get the pose of a given eye from RenderManager


### PR DESCRIPTION
Adds functionality for calling SetRoomRotationUsingHead() and ClearRoomToWorldRotation() on the RenderManager path. Created a sample script which "recenters" on a key press and added that to an empty gameobject in the VRFirstPerson.unity scene. Perhaps this gameobject should be a prefab?