### PR TITLE
Call GL.Clear(...) before issuing the render event. Render the previe…

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
@@ -215,13 +215,7 @@ namespace OSVR
             IEnumerator EndOfFrame()
             {
                 while (true)
-                {
-                    //if we disabled the dummy camera, enable it here
-                    if (_disabledCamera)
-                    {
-                        Camera.enabled = true;
-                        _disabledCamera = false;
-                    }
+                {                  
                     yield return new WaitForEndOfFrame();
                     if (DisplayController.UseRenderManager && DisplayController.CheckDisplayStartup())
                     {
@@ -237,6 +231,12 @@ namespace OSVR
                         Debug.LogError("GL.IssuePluginEvent failed. This version of Unity cannot support RenderManager.");
                         DisplayController.UseRenderManager = false;
 #endif
+                    }
+                    //if we disabled the dummy camera, enable it here
+                    if (_disabledCamera)
+                    {
+                        Camera.enabled = true;
+                        _disabledCamera = false;
                     }
 
                 }

--- a/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
@@ -176,20 +176,8 @@ namespace OSVR
             // OnPreRender is not called because we disable the camera here.
             void OnPreCull()
             {
-                
-                if(!DisplayController.CheckDisplayStartup())
-                {
-                    //leave this preview camera enabled if there is no display config
-                    _camera.enabled = true;
-                }
-                else
-                {
-                    // To save Render time, disable this camera here and re-enable after the frame
-                    // OR, in DirectMode, leave it on for "mirror" mode, although this is an expensive operation
-                    // The long-term solution is to provide a DirectMode preview window in RenderManager
-                    //@todo enable directmode preview in RenderManager
-                    _camera.enabled = DisplayController.UseRenderManager && DisplayController.showDirectModePreview;
-                }
+                //leave the preview camera enabled if there is no display config
+                _camera.enabled = !DisplayController.CheckDisplayStartup();
 
                 DoRendering();
 
@@ -239,7 +227,12 @@ namespace OSVR
                     {
                         // Issue a RenderEvent, which copies Unity RenderTextures to RenderManager buffers
 #if UNITY_5_2 || UNITY_5_3
-                        GL.IssuePluginEvent(DisplayController.RenderManager.GetRenderEventFunction(), OsvrRenderManager.RENDER_EVENT);
+                        GL.Clear(false, true, Camera.backgroundColor);
+                        GL.IssuePluginEvent(DisplayController.RenderManager.GetRenderEventFunction(), OsvrRenderManager.RENDER_EVENT); 
+                        if(DisplayController.showDirectModePreview)
+                        {
+                            Camera.Render();
+                        }                      
 #else
                         Debug.LogError("GL.IssuePluginEvent failed. This version of Unity cannot support RenderManager.");
                         DisplayController.UseRenderManager = false;


### PR DESCRIPTION
…w camera manually at the end of the frame. Fixes "whitewash" bug.