### PR TITLE
Better error handling

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/Sample/Demo/Scripts/Managers/ColorManager.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/Sample/Demo/Scripts/Managers/ColorManager.cs
@@ -121,7 +121,7 @@ public class ColorManager : MonoBehaviour
 	{
 		if ( index > colors.Length - 1 || index < 0 )
 		{
-			Debug.LogError( "Color value out of range." );
+            Debug.LogError("[OSVR-Unity-Samples] Color value out of range.");
 			return;
 		}
 
@@ -145,7 +145,7 @@ public class ColorManager : MonoBehaviour
 		{
 			ApplyColor( found.color );
 		}else{
-			Debug.LogError( "Color not found." );
+            Debug.LogError("[OSVR-Unity-Samples] Color not found.");
 		}
 	}
 

--- a/OSVR-Unity/Assets/OSVRUnity/Sample/Scripts/SampleAnalog.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/Sample/Scripts/SampleAnalog.cs
@@ -38,6 +38,6 @@ public class SampleAnalog : OSVR.Unity.RequiresAnalogInterface
 
     void Interface_StateChanged(object sender, OSVR.ClientKit.TimeValue timestamp, int sensor, double report)
     {
-        Debug.Log("Got analog value " + report);
+        Debug.Log("[OSVR-Unity-Samples] Got analog value " + report);
     }
 }

--- a/OSVR-Unity/Assets/OSVRUnity/Sample/Scripts/SampleButton.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/Sample/Scripts/SampleButton.cs
@@ -36,6 +36,6 @@ public class SampleButton : OSVR.Unity.RequiresButtonInterface
 
     void handleButton(object sender, OSVR.ClientKit.TimeValue timestamp, int sensor, byte report)
     {
-        Debug.Log("Got button: " + sensor.ToString() + " state is " + report);
+        Debug.Log("[OSVR-Unity-Samples] Got button: " + sensor.ToString() + " state is " + report);
     }
 }

--- a/OSVR-Unity/Assets/OSVRUnity/Sample/scripts/HandleButtonPress.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/Sample/scripts/HandleButtonPress.cs
@@ -34,6 +34,6 @@ public class HandleButtonPress : MonoBehaviour
 
     public void handleButton(object sender, OSVR.ClientKit.TimeValue timestamp, int sensor, byte report)
     {
-        Debug.Log("Got button: " + sensor.ToString() + " state is " + report.ToString());
+        Debug.Log("[OSVR-Unity-Samples] Got button: " + sensor.ToString() + " state is " + report.ToString());
     }
 }

--- a/OSVR-Unity/Assets/OSVRUnity/src/ClientKit.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/ClientKit.cs
@@ -33,6 +33,7 @@ namespace OSVR
 
             /// Uses the Unity "Persistent Singleton" pattern, see http://unitypatterns.com/singletons/
             private static ClientKit _instance;
+            private bool _osvrServerError = false;
 
             /// <summary>
             /// Use to access the single instance of this object/script in your game.
@@ -86,7 +87,16 @@ namespace OSVR
                 //check if the server is running
                 if (!_contextObject.CheckStatus())
                 {
-                    Debug.LogError("OSVR Server not detected. Start OSVR Server and restart the application.");
+                    if(!_osvrServerError)
+                    {
+                        _osvrServerError = true;
+                        Debug.LogError("OSVR Server not detected. Start OSVR Server and restart the application.");
+                    }                                    
+                }
+                else if(_osvrServerError)
+                {
+                    Debug.Log("OSVR Server connection established. You can ignore previous errors about the server not being detected.");
+                    _osvrServerError = false;
                 }
             }
 

--- a/OSVR-Unity/Assets/OSVRUnity/src/ClientKit.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/ClientKit.cs
@@ -47,7 +47,7 @@ namespace OSVR
                         _instance = GameObject.FindObjectOfType<ClientKit>();
                         if (_instance == null)
                         {
-                            Debug.LogError("OSVR Error: You need the ClientKit prefab in your game!!");
+                            Debug.LogError("[OSVR] Error: You need the ClientKit prefab in your game!!");
                         }
                         else
                         {
@@ -134,7 +134,7 @@ namespace OSVR
             {
                 if (null != _contextObject)
                 {
-                    Debug.Log("Shutting down OSVR.");
+                    Debug.Log("[OSVR] Shutting down OSVR.");
                     _contextObject.Dispose();
                     _contextObject = null;
                 }

--- a/OSVR-Unity/Assets/OSVRUnity/src/ClientKit.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/ClientKit.cs
@@ -48,7 +48,7 @@ namespace OSVR
                         _instance = GameObject.FindObjectOfType<ClientKit>();
                         if (_instance == null)
                         {
-                            Debug.LogError("[OSVR] Error: You need the ClientKit prefab in your game!!");
+                            Debug.LogError("[OSVR-Unity] Error: You need the ClientKit prefab in your game!!");
                         }
                         else
                         {
@@ -77,10 +77,10 @@ namespace OSVR
                 {
                     if (0 == AppID.Length)
                     {
-                        Debug.LogError("OSVR ClientKit instance needs AppID set to a reverse-order DNS name! Using dummy name...");
+                        Debug.LogError("[OSVR-Unity] ClientKit instance needs AppID set to a reverse-order DNS name! Using dummy name...");
                         AppID = "com.osvr.osvr-unity.dummy";
                     }
-                    Debug.Log("[OSVR] Starting with app ID: " + AppID);
+                    Debug.Log("[OSVR-Unity] Starting with app ID: " + AppID);
                     _contextObject = new OSVR.ClientKit.ClientContext(AppID, 0);
                 }
 
@@ -90,12 +90,12 @@ namespace OSVR
                     if(!_osvrServerError)
                     {
                         _osvrServerError = true;
-                        Debug.LogError("OSVR Server not detected. Start OSVR Server and restart the application.");
+                        Debug.LogError("[OSVR-Unity] OSVR Server not detected. Start OSVR Server and restart the application.");
                     }                                    
                 }
                 else if(_osvrServerError)
                 {
-                    Debug.Log("OSVR Server connection established. You can ignore previous errors about the server not being detected.");
+                    Debug.Log("[OSVR-Unity] OSVR Server connection established. You can ignore previous errors about the server not being detected.");
                     _osvrServerError = false;
                 }
             }
@@ -120,13 +120,13 @@ namespace OSVR
             }
             void Start()
             {
-                Debug.Log("[OSVR] In Start()");
+                Debug.Log("[OSVR-Unity] In Start()");
                 EnsureStarted();
             }
 
             void OnEnable()
             {
-                Debug.Log("[OSVR] In OnEnable()");
+                Debug.Log("[OSVR-Unity] In OnEnable()");
                 EnsureStarted();
             }
             
@@ -144,7 +144,7 @@ namespace OSVR
             {
                 if (null != _contextObject)
                 {
-                    Debug.Log("[OSVR] Shutting down OSVR.");
+                    Debug.Log("[OSVR-Unity] Shutting down OSVR.");
                     _contextObject.Dispose();
                     _contextObject = null;
                 }

--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -101,7 +101,7 @@ namespace OSVR
                 _clientKit = FindObjectOfType<ClientKit>();
                 if (_clientKit == null)
                 {
-                    Debug.LogError("[OSVR] DisplayController requires a ClientKit object in the scene.");
+                    Debug.LogError("[OSVR-Unity] DisplayController requires a ClientKit object in the scene.");
                 }
 
                 SetupApplicationSettings();
@@ -141,7 +141,7 @@ namespace OSVR
                     _useRenderManager = supportsRenderManager;
                     if (!_useRenderManager)
                     {
-                        Debug.LogError("[OSVR] RenderManager config found but RenderManager is not supported.");
+                        Debug.LogError("[OSVR-Unity] RenderManager config found but RenderManager is not supported.");
                         Destroy(_renderManager);
                     }
                     else
@@ -150,14 +150,14 @@ namespace OSVR
                         int result = _renderManager.InitRenderManager();
                         if (result != 0)
                         {
-                            Debug.LogError("[OSVR] Failed to create RenderManager.");
+                            Debug.LogError("[OSVR-Unity] Failed to create RenderManager.");
                             _useRenderManager = false;
                         }
                     }
                 }
                 else
                 {
-                    Debug.Log("[OSVR] RenderManager config not detected. Using normal Unity rendering path.");
+                    Debug.Log("[OSVR-Unity] RenderManager config not detected. Using normal Unity rendering path.");
                 }
             }
 
@@ -168,7 +168,7 @@ namespace OSVR
                 //get the DisplayConfig object from ClientKit
                 if (_clientKit.context == null)
                 {
-                    Debug.LogError("[OSVR] ClientContext is null. Can't setup display.");
+                    Debug.LogError("[OSVR-Unity] ClientContext is null. Can't setup display.");
                     return;
                 }
                 _displayConfig = _clientKit.context.GetDisplayConfig();
@@ -184,7 +184,7 @@ namespace OSVR
                 _viewerCount = _displayConfig.GetNumViewers();
                 if (_viewerCount != 1)
                 {
-                    Debug.LogError("[OSVR] " + _viewerCount + " viewers found, but this implementation requires exactly one viewer.");
+                    Debug.LogError("[OSVR-Unity] " + _viewerCount + " viewers found, but this implementation requires exactly one viewer.");
                     return;
                 }
 
@@ -243,7 +243,7 @@ namespace OSVR
                 _viewerCount = (uint)_displayConfig.GetNumViewers();
                 if (_viewerCount != NUM_VIEWERS)
                 {
-                    Debug.LogError("[OSVR] " + _viewerCount + " viewers detected. This implementation supports exactly one viewer.");
+                    Debug.LogError("[OSVR-Unity] " + _viewerCount + " viewers detected. This implementation supports exactly one viewer.");
                     return;
                 }
                 _viewers = new VRViewer[_viewerCount];

--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -103,7 +103,7 @@ namespace OSVR
                 {
                     Debug.LogError("DisplayController requires a ClientKit object in the scene.");
                 }
-                
+
                 SetupApplicationSettings();
             }
 
@@ -226,11 +226,11 @@ namespace OSVR
                 //Set the resolution. Don't force fullscreen if we have multiple display inputs
                 //We only need to do this if we aren't using RenderManager, because it adjusts the window size for us
                 //@todo figure out why this causes problems with direct mode, perhaps overfill factor?
-                if(numDisplayInputs > 1 && !UseRenderManager)
+                if (numDisplayInputs > 1 && !UseRenderManager)
                 {
                     Screen.SetResolution((int)TotalDisplayWidth, (int)TotalDisplayHeight, false);
-                }                             
-                
+                }
+
             }
 
             // Creates a head and eyes as configured in clientKit
@@ -290,7 +290,7 @@ namespace OSVR
                     GameObject vrViewer = new GameObject("VRViewer" + viewerIndex);
                     if (vrViewer.GetComponent<AudioListener>() == null)
                     {
-                    vrViewer.AddComponent<AudioListener>(); //add an audio listener
+                        vrViewer.AddComponent<AudioListener>(); //add an audio listener
                     }
 
                     VRViewer vrViewerComponent = vrViewer.AddComponent<VRViewer>();
@@ -326,16 +326,16 @@ namespace OSVR
             public bool CheckDisplayStartup()
             {
                 return _displayConfigInitialized && DisplayConfig.CheckDisplayStartup();
-                }
+            }
 
             public void ExitRenderManager()
             {
-                if(UseRenderManager && RenderManager != null)
+                if (UseRenderManager && RenderManager != null)
                 {
                     RenderManager.ExitRenderManager();
-                    }
-                        }
-                    }
                 }
             }
+        }
+    }
+}
 

--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -101,7 +101,7 @@ namespace OSVR
                 _clientKit = FindObjectOfType<ClientKit>();
                 if (_clientKit == null)
                 {
-                    Debug.LogError("DisplayController requires a ClientKit object in the scene.");
+                    Debug.LogError("[OSVR] DisplayController requires a ClientKit object in the scene.");
                 }
 
                 SetupApplicationSettings();
@@ -141,7 +141,7 @@ namespace OSVR
                     _useRenderManager = supportsRenderManager;
                     if (!_useRenderManager)
                     {
-                        Debug.LogError("RenderManager config found but RenderManager is not supported.");
+                        Debug.LogError("[OSVR] RenderManager config found but RenderManager is not supported.");
                         Destroy(_renderManager);
                     }
                     else
@@ -150,14 +150,14 @@ namespace OSVR
                         int result = _renderManager.InitRenderManager();
                         if (result != 0)
                         {
-                            Debug.LogError("Failed to create RenderManager.");
+                            Debug.LogError("[OSVR] Failed to create RenderManager.");
                             _useRenderManager = false;
                         }
                     }
                 }
                 else
                 {
-                    Debug.Log("RenderManager config not detected. Using normal Unity rendering path.");
+                    Debug.Log("[OSVR] RenderManager config not detected. Using normal Unity rendering path.");
                 }
             }
 
@@ -168,7 +168,7 @@ namespace OSVR
                 //get the DisplayConfig object from ClientKit
                 if (_clientKit.context == null)
                 {
-                    Debug.LogError("ClientContext is null. Can't setup display.");
+                    Debug.LogError("[OSVR] ClientContext is null. Can't setup display.");
                     return;
                 }
                 _displayConfig = _clientKit.context.GetDisplayConfig();
@@ -184,7 +184,7 @@ namespace OSVR
                 _viewerCount = _displayConfig.GetNumViewers();
                 if (_viewerCount != 1)
                 {
-                    Debug.LogError(_viewerCount + " viewers found, but this implementation requires exactly one viewer.");
+                    Debug.LogError("[OSVR] " + _viewerCount + " viewers found, but this implementation requires exactly one viewer.");
                     return;
                 }
 
@@ -243,7 +243,7 @@ namespace OSVR
                 _viewerCount = (uint)_displayConfig.GetNumViewers();
                 if (_viewerCount != NUM_VIEWERS)
                 {
-                    Debug.LogError(_viewerCount + " viewers detected. This implementation supports exactly one viewer.");
+                    Debug.LogError("[OSVR] " + _viewerCount + " viewers detected. This implementation supports exactly one viewer.");
                     return;
                 }
                 _viewers = new VRViewer[_viewerCount];

--- a/OSVR-Unity/Assets/OSVRUnity/src/InterfaceGameObjectBase.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/InterfaceGameObjectBase.cs
@@ -86,14 +86,14 @@ namespace OSVR.Unity
                 if (null != holder)
                 {
                     usedPath = holder.path;
-                    //print("[OSVR] " + name + ": Found path " + usedPath + " in ancestor " + go.name);
+                    //Debug.Log("[OSVR-Unity] " + name + ": Found path " + usedPath + " in ancestor " + go.name);
                 }
                 go = GetParent.Get(go);
             }
             
             if (0 == usedPath.Length)
             {
-                Debug.LogError("[OSVR] Missing path for " + name + " - no path found in this object's InterfaceGameObject or any ancestor!");
+                Debug.LogError("[OSVR-Unity] Missing path for " + name + " - no path found in this object's InterfaceGameObject or any ancestor!");
                 return;
             }
         }

--- a/OSVR-Unity/Assets/OSVRUnity/src/K1RadialDistortion.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/K1RadialDistortion.cs
@@ -62,7 +62,7 @@ namespace OSVR.Unity
 			Supported = DoSetup();
 			if (!Supported)
 			{
-				Debug.Log("Execution will proceed, but without shader-based distortion.");
+                Debug.Log("[OSVR-Unity] Execution will proceed, but without shader-based distortion.");
 			}
 		}
 
@@ -93,7 +93,7 @@ namespace OSVR.Unity
 				if (!ret.DistortionMaterial)
 				{
 					/// weird error case, shouldn't get here.
-					Debug.LogWarning("Couldn't create material in OSVR distortion shader factory - shouldn't be able to happen!");
+                    Debug.LogWarning("[OSVR-Unity] Couldn't create material in OSVR distortion shader factory - shouldn't be able to happen!");
 					ret.enabled = false;
 					return null;
 				}
@@ -110,18 +110,18 @@ namespace OSVR.Unity
 		{
 			if (!IsMinimallyCompatible)
 			{
-				Debug.Log("OSVR distortion shader not compatible with this version of Unity: requires image effects and render textures (4.6 Pro or 5.x)");
+                Debug.Log("[OSVR-Unity] distortion shader not compatible with this version of Unity: requires image effects and render textures (4.6 Pro or 5.x)");
 				return false;
 			}
 			DistortionShader = Shader.Find(ShaderName);
 			if (!DistortionShader)
 			{
-				Debug.Log("Could not find OSVR distortion shader '" + ShaderName + "' - must be in a Resource folder to be part of a build!");
+                Debug.Log("[OSVR-Unity] Could not find OSVR distortion shader '" + ShaderName + "' - must be in a Resource folder to be part of a build!");
 				return false;
 			}
 			if (!DistortionShader.isSupported)
 			{
-				Debug.Log("OSVR distortion shader found and loaded but not supported on this platform.");
+                Debug.Log("[OSVR-Unity] distortion shader found and loaded but not supported on this platform.");
 				DistortionShader = null;
 				return false;
 			}

--- a/OSVR-Unity/Assets/OSVRUnity/src/Math.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/Math.cs
@@ -73,7 +73,7 @@ namespace OSVR
                 }
                 else
                 {
-                    Debug.LogError("More than two video inputs is not supported. Using default viewport.");
+                    Debug.LogError("[OSVR] More than two video inputs is not supported. Using default viewport.");
                     return new Rect(0, 0, 0.5f, 1f);
                 }
             }

--- a/OSVR-Unity/Assets/OSVRUnity/src/Math.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/Math.cs
@@ -73,7 +73,7 @@ namespace OSVR
                 }
                 else
                 {
-                    Debug.LogError("[OSVR] More than two video inputs is not supported. Using default viewport.");
+                    Debug.LogError("[OSVR-Unity] More than two video inputs is not supported. Using default viewport.");
                     return new Rect(0, 0, 0.5f, 1f);
                 }
             }

--- a/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
@@ -227,7 +227,9 @@ namespace OSVR
                 catch (DllNotFoundException e)
                 {
                     result = -1;
-                    Debug.LogError("[OSVR-Unity] Could not load osvrUnityRenderingPlugin. The project is missing osvrUnityRenderingPlugin.dll, or one of its dependencies.");
+                    Debug.LogError("[OSVR-Unity] Could not load "  + e.Message +
+                        "\nosvrUnityRenderingPlugin.dll, or one of its dependencies, is missing from the project " + 
+                        "or architecture doesn't match.\n");
                 }
                 return result;
             }

--- a/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
@@ -227,7 +227,7 @@ namespace OSVR
                 catch (DllNotFoundException e)
                 {
                     result = -1;
-                    Debug.LogError("[OSVR] Could not load osvrUnityRenderingPlugin. The project is missing osvrUnityRenderingPlugin.dll, or one of its dependencies.");
+                    Debug.LogError("[OSVR-Unity] Could not load osvrUnityRenderingPlugin. The project is missing osvrUnityRenderingPlugin.dll, or one of its dependencies.");
                 }
                 return result;
             }
@@ -261,24 +261,24 @@ namespace OSVR
             {
                 bool support = true;
 #if UNITY_ANDROID
-                Debug.Log("[OSVR] RenderManager not yet supported on Android.");
+                Debug.Log("[OSVR-Unity] RenderManager not yet supported on Android.");
                 support = false;
 #endif
                 if (!SystemInfo.graphicsDeviceVersion.Contains("OpenGL") && !SystemInfo.graphicsDeviceVersion.Contains("Direct3D 11"))
                 {
-                    Debug.LogError("[OSVR] RenderManager not supported on " +
+                    Debug.LogError("[OSVR-Unity] RenderManager not supported on " +
                         SystemInfo.graphicsDeviceVersion + ". Only Direct3D11 is currently supported.");
                     support = false;
                 }
 
                 if (!SystemInfo.supportsRenderTextures)
                 {
-                    Debug.LogError("[OSVR] RenderManager not supported. RenderTexture (Unity Pro feature) is unavailable.");
+                    Debug.LogError("[OSVR-Unity] RenderManager not supported. RenderTexture (Unity Pro feature) is unavailable.");
                     support = false;
                 }
                 if (!IsUnityVersionSupported())
                 {
-                    Debug.LogError("[OSVR] RenderManager not supported. Unity 5.2+ is required for RenderManager support.");
+                    Debug.LogError("[OSVR-Unity] RenderManager not supported. Unity 5.2+ is required for RenderManager support.");
                     support = false;
                 }
                 return support;
@@ -298,7 +298,7 @@ namespace OSVR
                 }
                 catch
                 {
-                    Debug.LogWarning("[OSVR] Unable to determine Unity version from: " + Application.unityVersion);
+                    Debug.LogWarning("[OSVR-Unity] Unable to determine Unity version from: " + Application.unityVersion);
                     support = false;
                 }
                 return support;

--- a/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
@@ -227,7 +227,7 @@ namespace OSVR
                 catch (DllNotFoundException e)
                 {
                     result = -1;
-                    Debug.LogError("Could not load osvrUnityRenderingPlugin. The project is missing osvrUnityRenderingPlugin.dll, or one of its dependencies.");
+                    Debug.LogError("[OSVR] Could not load osvrUnityRenderingPlugin. The project is missing osvrUnityRenderingPlugin.dll, or one of its dependencies.");
                 }
                 return result;
             }
@@ -261,24 +261,24 @@ namespace OSVR
             {
                 bool support = true;
 #if UNITY_ANDROID
-                Debug.Log("RenderManager not yet supported on Android.");
+                Debug.Log("[OSVR] RenderManager not yet supported on Android.");
                 support = false;
 #endif
                 if (!SystemInfo.graphicsDeviceVersion.Contains("OpenGL") && !SystemInfo.graphicsDeviceVersion.Contains("Direct3D 11"))
                 {
-                    Debug.LogError("RenderManager not supported on " +
+                    Debug.LogError("[OSVR] RenderManager not supported on " +
                         SystemInfo.graphicsDeviceVersion + ". Only Direct3D11 is currently supported.");
                     support = false;
                 }
 
                 if (!SystemInfo.supportsRenderTextures)
                 {
-                    Debug.LogError("RenderManager not supported. RenderTexture (Unity Pro feature) is unavailable.");
+                    Debug.LogError("[OSVR] RenderManager not supported. RenderTexture (Unity Pro feature) is unavailable.");
                     support = false;
                 }
                 if (!IsUnityVersionSupported())
                 {
-                    Debug.LogError("RenderManager not supported. Unity 5.2+ is required for RenderManager support.");
+                    Debug.LogError("[OSVR] RenderManager not supported. Unity 5.2+ is required for RenderManager support.");
                     support = false;
                 }
                 return support;
@@ -298,7 +298,7 @@ namespace OSVR
                 }
                 catch
                 {
-                    Debug.LogWarning("Unable to determine Unity version from: " + Application.unityVersion);
+                    Debug.LogWarning("[OSVR] Unable to determine Unity version from: " + Application.unityVersion);
                     support = false;
                 }
                 return support;

--- a/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
@@ -219,7 +219,17 @@ namespace OSVR
             //Call the Unity Rendering Plugin to initialize the RenderManager
             public int CreateRenderManager(OSVR.ClientKit.ClientContext clientContext)
             {
-                return CreateRenderManagerFromUnity(clientContext.ContextHandle);
+                int result;
+                try
+                {
+                    result = CreateRenderManagerFromUnity(clientContext.ContextHandle);
+                }
+                catch (DllNotFoundException e)
+                {
+                    result = -1;
+                    Debug.LogError("Could not load osvrUnityRenderingPlugin. The project is missing osvrUnityRenderingPlugin.dll, or one of its dependencies.");
+                }
+                return result;
             }
 
             //Pass pointer to eye-camera RenderTexture to the Unity Rendering Plugin

--- a/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
@@ -171,7 +171,7 @@ namespace OSVR
                 _surfaces = new VRSurface[_surfaceCount];
                 if (surfaceCount != NUM_SURFACES)
                 {
-                    Debug.LogError("[OSVR] Eye" + _eyeIndex + " has " + surfaceCount + " surfaces, but " +
+                    Debug.LogError("[OSVR-Unity] Eye" + _eyeIndex + " has " + surfaceCount + " surfaces, but " +
                         "this implementation requires exactly one surface per eye.");
                     return;
                 }

--- a/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
@@ -171,7 +171,7 @@ namespace OSVR
                 _surfaces = new VRSurface[_surfaceCount];
                 if (surfaceCount != NUM_SURFACES)
                 {
-                    Debug.LogError("Eye" + _eyeIndex + " has " + surfaceCount + " surfaces, but " +
+                    Debug.LogError("[OSVR] Eye" + _eyeIndex + " has " + surfaceCount + " surfaces, but " +
                         "this implementation requires exactly one surface per eye.");
                     return;
                 }

--- a/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
@@ -56,7 +56,7 @@ namespace OSVR
             private uint _viewerIndex;
             private Camera _camera;
             private bool _disabledCamera = true;
-            
+            private bool _hmdConnectionError = false;
 
             #endregion
 
@@ -240,8 +240,13 @@ namespace OSVR
                 // update poses once DisplayConfig is ready
                 if (DisplayController.CheckDisplayStartup())
                 {
+                    if(_hmdConnectionError)
+                    {
+                        _hmdConnectionError = false;
+                        Debug.Log("HMD connection established. You can ignore previous error messages indicating Display Startup failure.");
+                    }
+
                     // update the viewer's head pose
-                    // @todo Get viewer pose from RenderManager if UseRenderManager = true
                     // currently getting viewer pose from DisplayConfig always
                     UpdateViewerHeadPose(GetViewerPose(ViewerIndex));
 
@@ -251,11 +256,14 @@ namespace OSVR
                 }
                 else
                 {
-                    if (!DisplayController.CheckDisplayStartup())
+                    if(!_hmdConnectionError)
                     {
-                        //@todo do something other than not show anything
+                        //report an error message once if the HMD is not connected
+                        //it can take a few frames to connect under normal operation, so inidcate when this error has been resolved
+                        _hmdConnectionError = true;
                         Debug.LogError("Display Startup failed. Check HMD connection.");
                     }
+                    
                 }
             }
 

--- a/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
@@ -180,7 +180,7 @@ namespace OSVR
 #if UNITY_5_2 || UNITY_5_3 || UNITY_5_4
                     GL.IssuePluginEvent(DisplayController.RenderManager.GetRenderEventFunction(), OsvrRenderManager.UPDATE_RENDERINFO_EVENT);
 #else
-                    Debug.LogError("GL.IssuePluginEvent failed. This version of Unity cannot support RenderManager.");
+                    Debug.LogError("[OSVR] GL.IssuePluginEvent failed. This version of Unity cannot support RenderManager.");
                     DisplayController.UseRenderManager = false;
 #endif
                 }
@@ -243,7 +243,7 @@ namespace OSVR
                     if(_hmdConnectionError)
                     {
                         _hmdConnectionError = false;
-                        Debug.Log("HMD connection established. You can ignore previous error messages indicating Display Startup failure.");
+                        Debug.Log("[OSVR] HMD connection established. You can ignore previous error messages indicating Display Startup failure.");
                     }
 
                     // update the viewer's head pose
@@ -261,7 +261,7 @@ namespace OSVR
                         //report an error message once if the HMD is not connected
                         //it can take a few frames to connect under normal operation, so inidcate when this error has been resolved
                         _hmdConnectionError = true;
-                        Debug.LogError("Display Startup failed. Check HMD connection.");
+                        Debug.LogError("[OSVR] Display Startup failed. Check HMD connection.");
                     }
                     
                 }
@@ -284,7 +284,7 @@ namespace OSVR
                             Camera.Render();
                         }                      
 #else
-                        Debug.LogError("GL.IssuePluginEvent failed. This version of Unity cannot support RenderManager.");
+                        Debug.LogError("[OSVR] GL.IssuePluginEvent failed. This version of Unity cannot support RenderManager.");
                         DisplayController.UseRenderManager = false;
 #endif
                     }

--- a/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
@@ -180,7 +180,7 @@ namespace OSVR
 #if UNITY_5_2 || UNITY_5_3 || UNITY_5_4
                     GL.IssuePluginEvent(DisplayController.RenderManager.GetRenderEventFunction(), OsvrRenderManager.UPDATE_RENDERINFO_EVENT);
 #else
-                    Debug.LogError("[OSVR] GL.IssuePluginEvent failed. This version of Unity cannot support RenderManager.");
+                    Debug.LogError("[OSVR-Unity] GL.IssuePluginEvent failed. This version of Unity cannot support RenderManager.");
                     DisplayController.UseRenderManager = false;
 #endif
                 }
@@ -243,7 +243,7 @@ namespace OSVR
                     if(_hmdConnectionError)
                     {
                         _hmdConnectionError = false;
-                        Debug.Log("[OSVR] HMD connection established. You can ignore previous error messages indicating Display Startup failure.");
+                        Debug.Log("[OSVR-Unity] HMD connection established. You can ignore previous error messages indicating Display Startup failure.");
                     }
 
                     // update the viewer's head pose
@@ -261,7 +261,7 @@ namespace OSVR
                         //report an error message once if the HMD is not connected
                         //it can take a few frames to connect under normal operation, so inidcate when this error has been resolved
                         _hmdConnectionError = true;
-                        Debug.LogError("[OSVR] Display Startup failed. Check HMD connection.");
+                        Debug.LogError("[OSVR-Unity] Display Startup failed. Check HMD connection.");
                     }
                     
                 }
@@ -284,7 +284,7 @@ namespace OSVR
                             Camera.Render();
                         }                      
 #else
-                        Debug.LogError("[OSVR] GL.IssuePluginEvent failed. This version of Unity cannot support RenderManager.");
+                        Debug.LogError("[OSVR-Unity] GL.IssuePluginEvent failed. This version of Unity cannot support RenderManager.");
                         DisplayController.UseRenderManager = false;
 #endif
                     }


### PR DESCRIPTION
Stops spamming of error messages when an HMD is not connected or the server has not started, by creating flags that are set when those errors are detected, and only printing each error message once. If those errors are resolved, another message is printed indicating the previous errors can be ignored.

Also includes some indentation and spacing issues in DisplayController.cs, and adds [OSVR] prefix to most debug log messages which aren't obvious that they are coming from OSVR, so it's immediately clear which messages relate to the OSVR-Unity plugin.