### PR TITLE
Check if DisplayConfig is null to avoid NullReferenceException

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -325,7 +325,7 @@ namespace OSVR
 
             public bool CheckDisplayStartup()
             {
-                return _displayConfigInitialized && DisplayConfig.CheckDisplayStartup();
+                return DisplayConfig != null && _displayConfigInitialized && DisplayConfig.CheckDisplayStartup();
             }
 
             public void ExitRenderManager()


### PR DESCRIPTION
In some cases the DisplayConfig variable can be null, resulting to a crash of the HMD.