### PR TITLE
Various fixes for scene loading

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/ClientKit.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/ClientKit.cs
@@ -35,6 +35,9 @@ namespace OSVR
             private static ClientKit _instance;
             private bool _osvrServerError = false;
 			private bool _dllFixed = false;
+            
+            [SerializeField]
+            private bool _dontDestroyOnLoad = true;
 
             /// <summary>
             /// Use to access the single instance of this object/script in your game.
@@ -53,7 +56,8 @@ namespace OSVR
                         }
                         else
                         {
-                            DontDestroyOnLoad(_instance.gameObject);
+                            if (_instance._dontDestroyOnLoad)
+                                DontDestroyOnLoad(_instance.gameObject);
                         }
                     }
                     return _instance;
@@ -113,7 +117,8 @@ namespace OSVR
                 if(_instance == null)
                 {
                     _instance = this;
-                    DontDestroyOnLoad(this);
+                    if (_dontDestroyOnLoad)
+                        DontDestroyOnLoad(this);
                 }
                 else
                 {

--- a/OSVR-Unity/Assets/OSVRUnity/src/ClientKit.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/ClientKit.cs
@@ -35,9 +35,6 @@ namespace OSVR
             private static ClientKit _instance;
             private bool _osvrServerError = false;
 			private bool _dllFixed = false;
-            
-            [SerializeField]
-            private bool _dontDestroyOnLoad = true;
 
             /// <summary>
             /// Use to access the single instance of this object/script in your game.
@@ -56,8 +53,7 @@ namespace OSVR
                         }
                         else
                         {
-                            if (_instance._dontDestroyOnLoad)
-                                DontDestroyOnLoad(_instance.gameObject);
+                            DontDestroyOnLoad(_instance.gameObject);
                         }
                     }
                     return _instance;
@@ -117,8 +113,7 @@ namespace OSVR
                 if(_instance == null)
                 {
                     _instance = this;
-                    if (_dontDestroyOnLoad)
-                        DontDestroyOnLoad(this);
+					DontDestroyOnLoad(this);
                 }
                 else
                 {

--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -54,6 +54,7 @@ namespace OSVR
             private bool _displayConfigInitialized = false;
             private uint _totalDisplayWidth;
             private uint _totalSurfaceHeight;
+			private bool _osvrClientKitError = false;
 
             //variables for controlling use of osvrUnityRenderingPlugin.dll which enables DirectMode
             private OsvrRenderManager _renderManager;
@@ -65,6 +66,7 @@ namespace OSVR
                 get { return _displayConfig; }
                 set { _displayConfig = value; }
             }
+			
             public VRViewer[] Viewers { get { return _viewers; } }
             public uint ViewerCount { get { return _viewerCount; } }
             public OsvrRenderManager RenderManager { get { return _renderManager; } }
@@ -72,28 +74,14 @@ namespace OSVR
 
             public uint TotalDisplayWidth
             {
-                get
-                {
-                    return _totalDisplayWidth;
-                }
-
-                set
-                {
-                    _totalDisplayWidth = value;
-                }
+                get { return _totalDisplayWidth; }
+                set { _totalDisplayWidth = value; }
             }
 
             public uint TotalDisplayHeight
             {
-                get
-                {
-                    return _totalSurfaceHeight;
-                }
-
-                set
-                {
-                    _totalSurfaceHeight = value;
-                }
+                get { return _totalSurfaceHeight; }
+                set { _totalSurfaceHeight = value; }
             }
 
             void Awake()
@@ -103,8 +91,8 @@ namespace OSVR
                 {
                     Debug.LogError("[OSVR-Unity] DisplayController requires a ClientKit object in the scene.");
                 }
-
-                SetupApplicationSettings();
+				
+				SetupApplicationSettings();
             }
 
             void SetupApplicationSettings()
@@ -166,11 +154,16 @@ namespace OSVR
             void SetupDisplay()
             {
                 //get the DisplayConfig object from ClientKit
-                if (_clientKit.context == null)
+                if (_clientKit == null || _clientKit.context == null)
                 {
-                    Debug.LogError("[OSVR-Unity] ClientContext is null. Can't setup display.");
+					if (!_osvrClientKitError)
+					{
+						Debug.LogError("[OSVR-Unity] ClientContext is null. Can't setup display.");
+						_osvrClientKitError = true;
+					}
                     return;
                 }
+				
                 _displayConfig = _clientKit.context.GetDisplayConfig();
                 if (_displayConfig == null)
                 {

--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -84,7 +84,7 @@ namespace OSVR
                 set { _totalSurfaceHeight = value; }
             }
 
-            void Awake()
+            void Start()
             {
                 _clientKit = FindObjectOfType<ClientKit>();
                 if (_clientKit == null)

--- a/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
@@ -85,7 +85,7 @@ namespace OSVR
 
             void OnEnable()
             {
-				Init()
+                Init();
 				
 				if (DisplayController != null)
 					StartCoroutine(_endOfFrameCoroutine);

--- a/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
@@ -58,6 +58,7 @@ namespace OSVR
             private bool _disabledCamera = true;
             private bool _hmdConnectionError = false;
             private Rect _emptyViewport = new Rect(0, 0, 0, 0);
+			private IEnumerator _endOfFrameCoroutine;
 
             #endregion
 
@@ -68,27 +69,38 @@ namespace OSVR
 
             void Init()
             {
-                _camera = GetComponent<Camera>();
-                //cache:
-                cachedTransform = transform;
-                if (DisplayController == null)
-                {
-                    DisplayController = FindObjectOfType<DisplayController>();
-                }
+				if (_camera == null)
+				{
+					_camera = GetComponent<Camera>();
+					//cache:
+					cachedTransform = transform;
+					if (DisplayController == null)
+					{
+						DisplayController = FindObjectOfType<DisplayController>();
+					}
+					
+					_endOfFrameCoroutine = EndOfFrame();
+				}
             }
 
             void OnEnable()
             {
-                StartCoroutine("EndOfFrame");
+				Init()
+				
+				if (DisplayController != null)
+					StartCoroutine(_endOfFrameCoroutine);
             }
 
             void OnDisable()
             {
-                StopCoroutine("EndOfFrame");
-                if (DisplayController.UseRenderManager && DisplayController.RenderManager != null)
-                {
-                    DisplayController.ExitRenderManager();
-                }
+				if (DisplayController != null)
+				{
+					StopCoroutine(_endOfFrameCoroutine);
+					if (DisplayController.UseRenderManager && DisplayController.RenderManager != null)
+					{
+						DisplayController.ExitRenderManager();
+					}
+				}
             }
 
             //Creates the Eyes of this Viewer


### PR DESCRIPTION
Hi, in my works to try to understand why the HMD crashes when we switch to another scene, I have started to do some refactoring/optimization.

First of all, this code is used in a real project already in production on multiple environements (PC, Android, Web)

Using a string for `Start/StopCoroutine` is not very good for performances (check the Unity docs), so I used a variable to store a reference to the `EndOfFrame` method.

Finally it is not necessary to spam the console if the `ClientKit` object is not present on the scene, so I added another flag to display a message one time only.