### PR TITLE
- Crash fix where loading a new unity scene…

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/Sample/Scripts/SetRoomRotationUsingHead.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/Sample/Scripts/SetRoomRotationUsingHead.cs
@@ -35,7 +35,7 @@ namespace OSVR
 
             void Awake()
             {
-                _clientKit = FindObjectOfType<ClientKit>();
+                _clientKit = ClientKit.instance;
                 _displayController = FindObjectOfType<DisplayController>();
             }
 

--- a/OSVR-Unity/Assets/OSVRUnity/src/ClientKit.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/ClientKit.cs
@@ -149,12 +149,17 @@ namespace OSVR
             }
 			
             void Stop()
-            {
-                if (null != _contextObject)
+        {
+                // Only stop the main instance, since it is the only one that
+                // ever actually starts-up.
+                if (this == instance)
                 {
-                    Debug.Log("[OSVR-Unity] Shutting down OSVR.");
-                    _contextObject.Dispose();
-                    _contextObject = null;
+                    if (null != _contextObject)
+                    {
+                        Debug.Log("[OSVR-Unity] Shutting down OSVR.");
+                        _contextObject.Dispose();
+                        _contextObject = null;
+                    }
                 }
             }
 

--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -86,7 +86,7 @@ namespace OSVR
 
             void Start()
             {
-                _clientKit = FindObjectOfType<ClientKit>();
+                _clientKit = ClientKit.instance;
                 if (_clientKit == null)
                 {
                     Debug.LogError("[OSVR-Unity] DisplayController requires a ClientKit object in the scene.");

--- a/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
@@ -120,7 +120,7 @@ namespace OSVR
                     //only use for debugging purposes, do not leave on for release.
                     LinkDebug(functionPointer); // Hook our c++ plugin into Unity's console log.
                 }
-                _clientKit = FindObjectOfType<ClientKit>();
+                _clientKit = ClientKit.instance;
                 //create a client context for RenderManager. This context should not be updated from Unity.
                 _renderManagerClientContext = new OSVR.ClientKit.ClientContext("com.sensics.rendermanagercontext", 0);
                 return CreateRenderManager(_renderManagerClientContext);


### PR DESCRIPTION
…  that already contains a ClientKit game object would crash the hmd.

[OSVR-Unity Issue 127](https://github.com/OSVR/OSVR-Unity/issues/127)