### PR TITLE
Removed call to surface.SetActiveRenderTexture, which caused an undoc…

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
@@ -124,7 +124,6 @@ namespace OSVR
                         surface.SetProjectionMatrix(Viewer.DisplayController.RenderManager.GetEyeProjectionMatrix((int)EyeIndex));
                    
                         surface.Render();
-                        surface.SetActiveRenderTexture();
                     }
                     else
                     {


### PR DESCRIPTION
…umented error message about "Relasing Active RenderTexture" when changing scenes.