### PR TITLE
Fix problem with Unity Anti Aliasing Quality setting being ignored in VR

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
@@ -220,6 +220,7 @@ namespace OSVR
 
                             //create a RenderTexture for this eye's camera to render into
                             RenderTexture renderTexture = new RenderTexture(surface.Viewport.Width, surface.Viewport.Height, 24, RenderTextureFormat.Default);
+                            renderTexture.antiAliasing = QualitySettings.antiAliasing;
                             surface.SetRenderTexture(renderTexture);
                         }
                     }
@@ -263,6 +264,7 @@ namespace OSVR
 
                         //create a RenderTexture for this eye's camera to render into
                         RenderTexture renderTexture = new RenderTexture(surface.Viewport.Width, surface.Viewport.Height, 24, RenderTextureFormat.Default);
+                        renderTexture.antiAliasing = QualitySettings.antiAliasing;
                         surface.SetRenderTexture(renderTexture);                       
                     }             
                 }


### PR DESCRIPTION
For more info see:

https://github.com/sensics/OSVR-RenderManager/issues/53