### PR TITLE
Fixes failure to create RenderTexture when QualitySettings antialiasing disabled.

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
@@ -220,7 +220,10 @@ namespace OSVR
 
                             //create a RenderTexture for this eye's camera to render into
                             RenderTexture renderTexture = new RenderTexture(surface.Viewport.Width, surface.Viewport.Height, 24, RenderTextureFormat.Default);
-                            renderTexture.antiAliasing = QualitySettings.antiAliasing;
+                            if (QualitySettings.antiAliasing > 0)
+                            {
+                                renderTexture.antiAliasing = QualitySettings.antiAliasing;
+                            }
                             surface.SetRenderTexture(renderTexture);
                         }
                     }
@@ -264,7 +267,10 @@ namespace OSVR
 
                         //create a RenderTexture for this eye's camera to render into
                         RenderTexture renderTexture = new RenderTexture(surface.Viewport.Width, surface.Viewport.Height, 24, RenderTextureFormat.Default);
-                        renderTexture.antiAliasing = QualitySettings.antiAliasing;
+                        if (QualitySettings.antiAliasing > 0)
+                        {
+                            renderTexture.antiAliasing = QualitySettings.antiAliasing;
+                        }
                         surface.SetRenderTexture(renderTexture);                       
                     }             
                 }


### PR DESCRIPTION
Fixes problem resulting from changes for my merged pull request  #140 
The `RenderTexture.antiAliasing` property only accepts values (1, 2, 4, 8) but `QualitySettings.antiAliasing` has a value of zero when disabled.