### PR TITLE
Render manager construct buffers

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -186,6 +186,7 @@ namespace OSVR
 
                 //create scene objects 
                 CreateHeadAndEyes();
+                RenderManager.ConstructBuffers();
                 SetRenderParams();
             }
 

--- a/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
@@ -74,6 +74,10 @@ namespace OSVR
             [DllImport(PluginName, CallingConvention = CallingConvention.Cdecl)]
             private static extern Byte CreateRenderManagerFromUnity(OSVR.ClientKit.SafeClientContextHandle /*OSVR_ClientContext*/ ctx);
 
+            //Create and Register RenderBuffers
+            [DllImport(PluginName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern Byte ConstructRenderBuffers();
+
             [StructLayout(LayoutKind.Sequential)]
             public struct OSVR_ViewportDescription
             {
@@ -124,6 +128,13 @@ namespace OSVR
                 //create a client context for RenderManager. This context should not be updated from Unity.
                 _renderManagerClientContext = new OSVR.ClientKit.ClientContext("com.sensics.rendermanagercontext", 0);
                 return CreateRenderManager(_renderManagerClientContext);
+            }
+
+            //Create and Register RenderBuffers in RenderManager
+            //Called after RM is created and after Unity RenderTexture's are created and assigned via SetEyeColorBuffer
+            public int ConstructBuffers()
+            {
+                return ConstructRenderBuffers();
             }
 
             public void SetNearClippingPlaneDistance(float near)


### PR DESCRIPTION
Adds a line in DisplayController.cs to Create RenderManager RenderBuffers after RenderManager and head/eyes/RenderTextures have been created. Previously, this was being done in the Unity Rendering Plugin in the same function that created/opened RenderManager. Here it is called from Unity after the RenderTextures have been created.