### PR TITLE
Create RM with the existing Unity Client Context, rather than creating a new one.

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
@@ -111,8 +111,6 @@ namespace OSVR
             [DllImport(PluginName, CallingConvention = CallingConvention.Cdecl)]
             private static extern void ShutdownRenderManager();
 
-            private OSVR.ClientKit.ClientContext _renderManagerClientContext;
-            private ClientKit _clientKit;
             private bool _linkDebug = false; //causes crash on exit if true, only enable for debugging
 
             //Initialize use of RenderManager via CreateRenderManager call
@@ -124,10 +122,8 @@ namespace OSVR
                     //only use for debugging purposes, do not leave on for release.
                     LinkDebug(functionPointer); // Hook our c++ plugin into Unity's console log.
                 }
-                _clientKit = ClientKit.instance;
-                //create a client context for RenderManager. This context should not be updated from Unity.
-                _renderManagerClientContext = new OSVR.ClientKit.ClientContext("com.sensics.rendermanagercontext", 0);
-                return CreateRenderManager(_renderManagerClientContext);
+
+                return CreateRenderManager(ClientKit.instance.context);
             }
 
             //Create and Register RenderBuffers in RenderManager
@@ -156,7 +152,7 @@ namespace OSVR
             public void SetRoomRotationUsingHead()
             {
 #if UNITY_5_2 || UNITY_5_3 || UNITY_5_4
-                _clientKit.context.SetRoomRotationUsingHead();
+                ClientKit.instance.context.SetRoomRotationUsingHead();
                 GL.IssuePluginEvent(GetRenderEventFunc(), 3);
 #endif
             }
@@ -165,7 +161,7 @@ namespace OSVR
             public void ClearRoomToWorldTransform()
             {
 #if UNITY_5_2 || UNITY_5_3 || UNITY_5_4
-                _clientKit.context.ClearRoomToWorldTransform();
+                ClientKit.instance.context.ClearRoomToWorldTransform();
                 GL.IssuePluginEvent(GetRenderEventFunc(), 4);
 #endif
             }
@@ -261,11 +257,6 @@ namespace OSVR
             public void ExitRenderManager()
             {
                 ShutdownRenderManager();
-                if (null != _renderManagerClientContext)
-                {
-                    _renderManagerClientContext.Dispose();
-                    _renderManagerClientContext = null;
-                }
             }
 
             //helper functions to determine is RenderManager is supported


### PR DESCRIPTION
Fixes issue causing Unity/OSVR server to hang on some systems. Might address the scene switching issues some people are having (https://github.com/OSVR/OSVR-Unity/issues/127). Can somebody with the scene switching bug test this?