### PR TITLE
Fix: Create an interface from script

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/InterfaceGameObject.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/InterfaceGameObject.cs
@@ -21,68 +21,110 @@
 using UnityEngine;
 using System.Collections;
 
-namespace OSVR
+namespace OSVR.Unity
 {
-    namespace Unity
+    /// <summary>
+    /// A script component to add to a GameObject in order to access an interface, managing lifetime and centralizing the path specification.
+    /// </summary>
+    public class InterfaceGameObjectBase : MonoBehaviour
     {
+        /// <summary>
+        /// The interface path you want to connect to. If you end up with a parent-child relationship between two InterfaceGameObjects
+        /// in your scene, there is the ability to inherit the path. There are a few instances where this might be useful, but typically
+        /// each instance would have the path explicitly specified.
+        /// </summary>
+        [Tooltip("The interface path you want to access. If left blank, the path of the nearest ancestor with a path will be used.")]
+        public string path;
+        protected string usedPath;
+        #region Private implementation
+
+        private class PathHolder : MonoBehaviour
+        {
+            [HideInInspector]
+            public string path;
+
+            void Awake()
+            {
+                hideFlags = HideFlags.HideAndDontSave;
+            }
+        }
+        #endregion
+
+        #region Methods for Derived Classes
+        /// <summary>
+        /// Call from your Awake method to advertise the presence or absence of a path specification on this game object.
+        /// </summary>
+        protected void AdvertisePath()
+        {
+            PathHolder holder = GetComponent<PathHolder>();
+            if (path.Length > 0)
+            {
+                /// If we have a path, be sure we advertise it.
+                if (null == holder)
+                {
+                    holder = gameObject.AddComponent<PathHolder>();
+                }
+                holder.path = path;
+            }
+            else
+            {
+                /// Don't advertise a path that is empty
+                if (null != holder)
+                {
+                    Object.Destroy(holder);
+                }
+            }
+        }
 
         /// <summary>
-        /// (OBSOLETE) A script component to add to a GameObject in order to access an interface, managing lifetime and centralizing the path specification.
+        /// Call from your Start method
         /// </summary>
-        [System.Obsolete("Use one of the OSVR.Unity.Requires*Interface base classes instead.")]
-        public class InterfaceGameObject : InterfaceGameObjectBase
+        protected virtual void Start()
         {
-            public InterfaceCallbacks osvrInterface
+            AdvertisePath();
+            GameObject go = this.gameObject;
+            PathHolder holder = null;
+            while (null != go && System.String.IsNullOrEmpty(usedPath))
             {
-                get
+                usedPath = path;
+                holder = go.GetComponent<PathHolder>();
+                if (null != holder)
                 {
-                    Start();
-                    return iface;
+                    usedPath = holder.path;
+                    //Debug.Log("[OSVR-Unity] " + name + ": Found path " + usedPath + " in ancestor " + go.name);
                 }
+                go = GetParent.Get(go);
             }
 
-            protected InterfaceGameObject interfaceGameObject
+            if (0 == usedPath.Length)
             {
-                get
-                {
-                    return GetComponent<InterfaceGameObject>();
-                }
+                Debug.LogError("[OSVR-Unity] Missing path for " + name + " - no path found in this object's InterfaceGameObject or any ancestor!");
+                return;
             }
-
-            #region Private implementation
-
-            private InterfaceCallbacks iface;
-
-            #endregion
-
-            #region Methods for Derived Classes
-
-            /// <summary>
-            /// Call from your Start method
-            /// </summary>
-            protected override void Start()
-            {
-                base.Start ();
-                if (null != iface)
-                {
-                    return;
-                }
-
-                iface = ScriptableObject.CreateInstance<InterfaceCallbacks>();
-                iface.path = usedPath;
-                iface.Start();
-            }
-
-            protected override void Stop()
-            {
-                base.Stop ();
-                if (null != iface)
-                {
-                    Object.Destroy(iface);
-                    iface = null;
-                }
-            }
-            #endregion
         }
+
+        protected virtual void Stop()
+        {
+            PathHolder holder = GetComponent<PathHolder>();
+            if (null != holder)
+            {
+                Object.Destroy(holder);
+            }
+        }
+        #endregion
+
+        #region Event Methods        
+        void OnDestroy()
+        {
+            Stop();
+        }
+
+        void OnApplicationQuit()
+        {
+            Stop();
+        }
+
+        #endregion
+
     }
 }

--- a/OSVR-Unity/Assets/OSVRUnity/src/InterfaceGameObjectBase.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/InterfaceGameObjectBase.cs
@@ -43,7 +43,7 @@ namespace OSVR.Unity
             [HideInInspector]
             public string path;
             
-            PathHolder()
+            void Awake()
             {
                 hideFlags = HideFlags.HideAndDontSave;
             }
@@ -108,12 +108,7 @@ namespace OSVR.Unity
         }
         #endregion
         
-        #region Event Methods
-        void Awake()
-        {
-            AdvertisePath();
-        }
-        
+        #region Event Methods        
         void OnDestroy()
         {
             Stop();


### PR DESCRIPTION
- Don't call the `MonoBehaviour`'s contructor
- Don't call `AdvertisePath` on Awake, but on Start. If you attach a script to a `GameObject`, the Awake method is called, so you haven't the time to change the path of the interface.