### PR TITLE
Added an option to enable or disable the auto start feature

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/ClientKit.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/ClientKit.cs
@@ -32,6 +32,8 @@ namespace OSVR
             private OSVR.ClientKit.ClientContext _contextObject;
 #if UNITY_STANDALONE_WIN
             private OSVR.ClientKit.ServerAutoStarter _serverAutoStarter;
+
+            public bool autoStartServer = true;
 #endif
 
             /// Uses the Unity "Persistent Singleton" pattern, see http://unitypatterns.com/singletons/
@@ -95,7 +97,7 @@ namespace OSVR
                 }
 
 #if UNITY_STANDALONE_WIN
-                if(_serverAutoStarter == null)
+                if(_serverAutoStarter == null && autoStartServer)
                 {
                     _serverAutoStarter = new OSVR.ClientKit.ServerAutoStarter();
                 }


### PR DESCRIPTION
The auto server start is a nice feature. However if a user doesn't want to use OSVR (he want to play in flat mode), he can't, he has to unplug its HMD from its computer.

If you use Unity 5.4 with the OpenVR API enabled AND you have the OSVR-SteamVR driver, then this feature will start OSVR then start SteamVR and the final API used will be SteamVR. So please, let us choose when enable the server. It's usefull for many cases, but not all.