### PR TITLE
Flush buffers

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -97,14 +97,13 @@ namespace OSVR
             }
 
             void SetupApplicationSettings()
-            {
-                //VR should never timeout the screen:
-                Screen.sleepTimeout = SleepTimeout.NeverSleep;
-
-                //Set the framerate
-                //@todo get this value from OSVR, not a const value
-                //Performance note: Developers should try setting Time.fixedTimestep to 1/Application.targetFrameRate
-                //Application.targetFrameRate = TARGET_FRAME_RATE;
+            {             
+                //Set the framerate and performance settings
+                Application.targetFrameRate = -1;
+                Application.runInBackground = true;
+                QualitySettings.vSyncCount = 0;
+                QualitySettings.maxQueuedFrames = -1; //limit the number of frames queued up to be rendered, reducing latency
+                Screen.sleepTimeout = SleepTimeout.NeverSleep;  //VR should never timeout the screen:
             }
 
             // Setup RenderManager for DirectMode or non-DirectMode rendering.

--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -315,6 +315,12 @@ namespace OSVR
                 {
                     SetupDisplay();
                 }
+
+                //Sends queued-up commands in the driver's command buffer to the GPU.
+                //only accessible in Unity 5.4+ API
+#if !(UNITY_5_3 || UNITY_5_2 || UNITY_5_1 || UNITY_5_0 || UNITY_4_7 || UNITY_4_6)
+                GL.Flush();
+#endif
             }
 
             //helper method for updating the client context

--- a/OSVR-Unity/Assets/OSVRUnity/src/VRSurface.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRSurface.cs
@@ -155,6 +155,11 @@ namespace OSVR
             {
                 Camera.targetTexture = RenderToTexture;
                 Camera.Render();
+                //Sends queued-up commands in the driver's command buffer to the GPU.
+                //only accessible in Unity 5.4+ API
+#if !(UNITY_5_3 || UNITY_5_2 || UNITY_5_1 || UNITY_5_0 || UNITY_4_7 || UNITY_4_6)
+                GL.Flush();
+#endif
             }
 
             public void ClearRenderTarget()

--- a/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
@@ -239,6 +239,12 @@ namespace OSVR
 
                 DoRendering();
 
+                //Sends queued-up commands in the driver's command buffer to the GPU.
+                //only accessible in Unity 5.4+ API
+#if !(UNITY_5_3 || UNITY_5_2 || UNITY_5_1 || UNITY_5_0 || UNITY_4_7 || UNITY_4_6)
+                GL.Flush();
+#endif
+
                 // Flag that we disabled the camera
                 _disabledCamera = true;
             }
@@ -306,7 +312,11 @@ namespace OSVR
                         Camera.enabled = true;
                         _disabledCamera = false;
                     }
-
+                    //Sends queued-up commands in the driver's command buffer to the GPU.
+                    //only accessible in Unity 5.4+ API
+#if !(UNITY_5_3 || UNITY_5_2 || UNITY_5_1 || UNITY_5_0 || UNITY_4_7 || UNITY_4_6)
+                GL.Flush();
+#endif
                 }
             }             
         }


### PR DESCRIPTION
Some changes to improve latency/performance, including forcing optimal player settings, and calling GL.Flush() in Update loop, after rendering each surface, and at the end of each frame, to keep the GPU busy (only applicable in Unity 5.4).
