### PR TITLE
Faster mirror mode

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/VRSurface.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRSurface.cs
@@ -157,6 +157,17 @@ namespace OSVR
                 Camera.Render();
             }
 
+            void OnRenderImage(RenderTexture source, RenderTexture destination)
+            {
+                //blit to the active RenderTexture
+                Graphics.Blit(source, destination);
+                //if mirror mode is enabled, right-eye-only blit to the Unity game window
+                if (Eye.Viewer.DisplayController.UseRenderManager && Eye.Viewer.DisplayController.showDirectModePreview && Eye.EyeIndex == 1)
+                {
+                    Graphics.Blit(source, null as RenderTexture);
+                }
+            }
+
             public void ClearRenderTarget()
             {
                 if (RenderTexture.active != null)

--- a/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
@@ -289,12 +289,7 @@ namespace OSVR
 #if UNITY_5_2 || UNITY_5_3 || UNITY_5_4 || UNITY_5_5
                         GL.Viewport(_emptyViewport);
                         GL.Clear(false, true, Camera.backgroundColor);                      
-                        GL.IssuePluginEvent(DisplayController.RenderManager.GetRenderEventFunction(), OsvrRenderManager.RENDER_EVENT); 
-                        if(DisplayController.showDirectModePreview)
-                        {
-                            Camera.Render();
-                        } 
-                                             
+                        GL.IssuePluginEvent(DisplayController.RenderManager.GetRenderEventFunction(), OsvrRenderManager.RENDER_EVENT);                                            
 #else
                         Debug.LogError("[OSVR-Unity] GL.IssuePluginEvent failed. This version of Unity cannot support RenderManager.");
                         DisplayController.UseRenderManager = false;


### PR DESCRIPTION
Not ready to merge.
Possibly better performance mirror mode by blitting one eye texture to the game view instead of rendering an extra camera. The Profiler appears to show a savings of a couple MS per frame in the EndOfFrame coroutine (the function where we would render the extra camera), and no significant gained time from the Blit, but I'm having trouble verifying it's an improvement. At first it appeared to be, but I ran some tests with Nsight in a complex scene that showed lower FPS with this new method. Will continue testing, would be great if others can test this.