### PR TITLE
Updated Marshalled data types

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/Math.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/Math.cs
@@ -81,6 +81,11 @@ namespace OSVR
             {
                 //Unity expects normalized coordinates, not pixel coordinates
                 //@todo below assumes left and right eyes split the screen in half horizontally
+                if(viewport.Width == 0 || viewport.Height == 0)
+                {
+                    Debug.LogError("[OSVR-Unity] Viewport width/height is 0. Avoiding divide by zero error, returning default viewport.");
+                    return new Rect(0, 0, 0.5f, 1);
+                }
                 return new Rect(viewport.Left / viewport.Width, viewport.Bottom / viewport.Height, viewport.Width / viewport.Width, 1);
             }
 

--- a/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VREye.cs
@@ -40,8 +40,8 @@ namespace OSVR
             private VRSurface[] _surfaces; //the surfaces associated with this eye
             private uint _surfaceCount;
             private uint _eyeIndex;
-            
-            
+
+
             #endregion
             #region Public Variables  
             public uint EyeIndex
@@ -49,7 +49,7 @@ namespace OSVR
                 get { return _eyeIndex; }
                 set { _eyeIndex = value; }
             }
-            public VRSurface[] Surfaces { get { return _surfaces; } } 
+            public VRSurface[] Surfaces { get { return _surfaces; } }
             public uint SurfaceCount { get { return _surfaceCount; } }
             public VRViewer Viewer
             {
@@ -75,7 +75,7 @@ namespace OSVR
             {
                 //cache:
                 cachedTransform = transform;
-            }         
+            }
             #endregion
 
             // Updates the position and rotation of the eye
@@ -117,23 +117,23 @@ namespace OSVR
                     //get viewport from ClientKit and set surface viewport
                     if (Viewer.DisplayController.UseRenderManager)
                     {
-                        viewport = Viewer.DisplayController.RenderManager.GetEyeViewport((int)EyeIndex);
+                        viewport = Viewer.DisplayController.RenderManager.GetEyeViewport((Byte)EyeIndex);
                         surface.SetViewportRect(Math.ConvertViewportRenderManager(viewport));
 
                         //get projection matrix from RenderManager and set surface projection matrix
-                        surface.SetProjectionMatrix(Viewer.DisplayController.RenderManager.GetEyeProjectionMatrix((int)EyeIndex));
-                   
+                        surface.SetProjectionMatrix(Viewer.DisplayController.RenderManager.GetEyeProjectionMatrix((Byte)EyeIndex));
+
                         surface.Render();
                     }
                     else
                     {
                         //get viewport from ClientKit and set surface viewport
                         viewport = Viewer.DisplayController.DisplayConfig.GetRelativeViewportForViewerEyeSurface(
-                            Viewer.ViewerIndex, (byte)_eyeIndex, surfaceIndex);
+                            Viewer.ViewerIndex, (Byte)_eyeIndex, surfaceIndex);
 
-                        int displayInputIndex = Viewer.DisplayController.DisplayConfig.GetViewerEyeSurfaceDisplayInputIndex(Viewer.ViewerIndex, (byte)_eyeIndex, surfaceIndex);
+                        int displayInputIndex = Viewer.DisplayController.DisplayConfig.GetViewerEyeSurfaceDisplayInputIndex(Viewer.ViewerIndex, (Byte)_eyeIndex, surfaceIndex);
                         int numDisplayInputs = Viewer.DisplayController.DisplayConfig.GetNumDisplayInputs();
-                        surface.SetViewportRect(Math.ConvertViewport(viewport, Viewer.DisplayController.DisplayConfig.GetDisplayDimensions((byte)displayInputIndex),
+                        surface.SetViewportRect(Math.ConvertViewport(viewport, Viewer.DisplayController.DisplayConfig.GetDisplayDimensions((Byte)displayInputIndex),
                             numDisplayInputs, (int)_eyeIndex, (int)Viewer.DisplayController.TotalDisplayWidth));
 
                         //get projection matrix from ClientKit and set surface projection matrix
@@ -145,7 +145,7 @@ namespace OSVR
 
                         //render the surface
                         surface.Render();
-                    }                           
+                    }
 
                 }
             }
@@ -209,14 +209,14 @@ namespace OSVR
                             //get distortion parameters
                             OSVR.ClientKit.RadialDistortionParameters distortionParameters =
                             Viewer.DisplayController.DisplayConfig.GetViewerEyeSurfaceRadialDistortion(
-                            Viewer.ViewerIndex, (byte)_eyeIndex, surfaceIndex);                    
+                            Viewer.ViewerIndex, (byte)_eyeIndex, surfaceIndex);
                             surface.SetDistortion(distortionParameters);
                         }
 
                         //render manager
                         if (Viewer.DisplayController.UseRenderManager)
                         {
-                            surface.SetViewport(Viewer.DisplayController.RenderManager.GetEyeViewport((int)EyeIndex));
+                            surface.SetViewport(Viewer.DisplayController.RenderManager.GetEyeViewport((Byte)EyeIndex));
 
                             //create a RenderTexture for this eye's camera to render into
                             RenderTexture renderTexture = new RenderTexture(surface.Viewport.Width, surface.Viewport.Height, 24, RenderTextureFormat.Default);
@@ -247,7 +247,7 @@ namespace OSVR
 
                     //distortion
                     bool useDistortion = Viewer.DisplayController.DisplayConfig.DoesViewerEyeSurfaceWantDistortion(Viewer.ViewerIndex, (byte)_eyeIndex, surfaceIndex);
-                    if(useDistortion)
+                    if (useDistortion)
                     {
                         //@todo figure out which type of distortion to use
                         //right now, there is only one option, SurfaceRadialDistortion
@@ -257,13 +257,13 @@ namespace OSVR
                         Viewer.ViewerIndex, (byte)_eyeIndex, surfaceIndex);
 
                         surface.SetDistortion(distortionParameters);
-                    }    
-                    
+                    }
+
                     //render manager
-                    if(Viewer.DisplayController.UseRenderManager)
+                    if (Viewer.DisplayController.UseRenderManager)
                     {
                         //Set the surfaces viewport from RenderManager
-                        surface.SetViewport(Viewer.DisplayController.RenderManager.GetEyeViewport((int)EyeIndex));
+                        surface.SetViewport(Viewer.DisplayController.RenderManager.GetEyeViewport((Byte)EyeIndex));
 
                         //create a RenderTexture for this eye's camera to render into
                         RenderTexture renderTexture = new RenderTexture(surface.Viewport.Width, surface.Viewport.Height, 24, RenderTextureFormat.Default);
@@ -271,8 +271,8 @@ namespace OSVR
                         {
                             renderTexture.antiAliasing = QualitySettings.antiAliasing;
                         }
-                        surface.SetRenderTexture(renderTexture);                       
-                    }             
+                        surface.SetRenderTexture(renderTexture);
+                    }
                 }
             }
 
@@ -284,7 +284,7 @@ namespace OSVR
                 destCamera.CopyFrom(srcCamera);
                 destCamera.depth = 0;
                 //@todo Copy other components attached to the DisplayController?
-            }           
+            }
         }
     }
 }

--- a/OSVR-Unity/Assets/OSVRUnity/src/VRSurface.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRSurface.cs
@@ -26,6 +26,7 @@ using UnityEngine;
 using UnityEngine.Rendering;
 using System.Collections;
 using System.Runtime.InteropServices;
+using System;
 
 namespace OSVR
 {
@@ -48,7 +49,7 @@ namespace OSVR
             public Camera Camera { get { return _camera; } set { _camera = value; } }
             public uint SurfaceIndex { get { return _surfaceIndex; } set { _surfaceIndex = value; } }
             public VREye Eye { get { return _eye; } set { _eye = value; } }
-            public OSVR.ClientKit.Viewport Viewport { get { return _viewport;} set {_viewport = value;} }
+            public OSVR.ClientKit.Viewport Viewport { get { return _viewport; } set { _viewport = value; } }
 
             [HideInInspector]
             public K1RadialDistortion DistortionEffect
@@ -137,9 +138,9 @@ namespace OSVR
                 RenderToTexture = rt;
                 Camera.targetTexture = RenderToTexture;
                 RenderTexture.active = RenderToTexture;
-                
+
                 //Set the native texture pointer so we can access this texture from the plugin
-                Eye.Viewer.DisplayController.RenderManager.SetEyeColorBuffer(RenderToTexture.GetNativeTexturePtr(), (int)Eye.EyeIndex);
+                Eye.Viewer.DisplayController.RenderManager.SetEyeColorBuffer(RenderToTexture.GetNativeTexturePtr(), (Byte)Eye.EyeIndex);
             }
             public RenderTexture GetRenderTexture()
             {


### PR DESCRIPTION
Changed int to Byte when passing Eye indices to Unity Rendering Plugin.
Avoids a divide by zero error when a bug results in GetViewport returning a zeroed viewport.
This is a workaround to avoid a crash, not a fix for what may be a stack corruption bug.