### PR TITLE
Avoid null reference when server isn't running and user tries to call…

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/Sample/Scripts/SetRoomRotationUsingHead.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/Sample/Scripts/SetRoomRotationUsingHead.cs
@@ -50,7 +50,10 @@ namespace OSVR
                     }
                     else
                     {
-                        _clientKit.context.SetRoomRotationUsingHead();
+                        if(_clientKit.context.CheckStatus())
+                        {
+                            _clientKit.context.SetRoomRotationUsingHead();
+                        }
                     }
                 }
                 if (Input.GetKeyDown(clearRoomRotationKey))


### PR DESCRIPTION
… SetRoomRotationUsingHead

Addresses https://github.com/OSVR/OSVR-Unity/issues/197