### PR TITLE
Adds OsvrMirrorDisplay component, removes Direct Mode Preview

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/Prefabs/VRDisplayTracked.prefab
+++ b/OSVR-Unity/Assets/OSVRUnity/Prefabs/VRDisplayTracked.prefab
@@ -5,11 +5,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 400508}
-  - 20: {fileID: 2000508}
-  - 114: {fileID: 11400508}
+  - component: {fileID: 400508}
+  - component: {fileID: 2000508}
+  - component: {fileID: 11400508}
   m_Layer: 0
   m_Name: VRViewer0
   m_TagString: MainCamera
@@ -22,10 +22,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 431736}
-  - 114: {fileID: 11463916}
+  - component: {fileID: 431736}
+  - component: {fileID: 11463916}
+  - component: {fileID: 114784643541613048}
   m_Layer: 0
   m_Name: VRDisplayTracked
   m_TagString: Untagged
@@ -38,10 +39,10 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 461702}
-  - 114: {fileID: 11461702}
+  - component: {fileID: 461702}
+  - component: {fileID: 11461702}
   m_Layer: 0
   m_Name: VREye0
   m_TagString: Untagged
@@ -54,11 +55,11 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 461704}
-  - 20: {fileID: 2061704}
-  - 114: {fileID: 11461704}
+  - component: {fileID: 461704}
+  - component: {fileID: 2061704}
+  - component: {fileID: 11461704}
   m_Layer: 0
   m_Name: VRSurface0
   m_TagString: Untagged
@@ -79,6 +80,7 @@ Transform:
   - {fileID: 461702}
   m_Father: {fileID: 431736}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &431736
 Transform:
   m_ObjectHideFlags: 1
@@ -92,6 +94,7 @@ Transform:
   - {fileID: 400508}
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &461702
 Transform:
   m_ObjectHideFlags: 1
@@ -105,6 +108,7 @@ Transform:
   - {fileID: 461704}
   m_Father: {fileID: 400508}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &461704
 Transform:
   m_ObjectHideFlags: 1
@@ -117,6 +121,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 461702}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!20 &2000508
 Camera:
   m_ObjectHideFlags: 1
@@ -245,3 +250,17 @@ Prefab:
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 131736}
   m_IsPrefabParent: 1
+--- !u!114 &114784643541613048
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 131736}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3bd92c411e0576c4aad0b30645a3d4c7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fixAspectRatio: 1
+  mirrorCamera: {fileID: 0}
+  fillTexture: {fileID: 0}

--- a/OSVR-Unity/Assets/OSVRUnity/Prefabs/VRFirstPersonController.prefab
+++ b/OSVR-Unity/Assets/OSVRUnity/Prefabs/VRFirstPersonController.prefab
@@ -5,11 +5,11 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 450052}
-  - 20: {fileID: 2050052}
-  - 114: {fileID: 11450052}
+  - component: {fileID: 450052}
+  - component: {fileID: 2050052}
+  - component: {fileID: 11450052}
   m_Layer: 0
   m_Name: VRSurface0
   m_TagString: Untagged
@@ -22,10 +22,10 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 450054}
-  - 114: {fileID: 11450054}
+  - component: {fileID: 450054}
+  - component: {fileID: 11450054}
   m_Layer: 0
   m_Name: VREye0
   m_TagString: Untagged
@@ -38,11 +38,11 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 450056}
-  - 20: {fileID: 2050054}
-  - 114: {fileID: 11450056}
+  - component: {fileID: 450056}
+  - component: {fileID: 2050054}
+  - component: {fileID: 11450056}
   m_Layer: 0
   m_Name: VRViewer0
   m_TagString: MainCamera
@@ -55,10 +55,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 450058}
-  - 114: {fileID: 11450058}
+  - component: {fileID: 450058}
+  - component: {fileID: 11450058}
+  - component: {fileID: 114111526175316250}
   m_Layer: 0
   m_Name: VRDisplayTracked
   m_TagString: Untagged
@@ -71,13 +72,13 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 463458}
-  - 143: {fileID: 14363460}
-  - 114: {fileID: 11463456}
-  - 114: {fileID: 11463458}
-  - 114: {fileID: 11463460}
+  - component: {fileID: 463458}
+  - component: {fileID: 14363460}
+  - component: {fileID: 11463456}
+  - component: {fileID: 11463458}
+  - component: {fileID: 11463460}
   m_Layer: 0
   m_Name: VRFirstPersonController
   m_TagString: Untagged
@@ -90,11 +91,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 463460}
-  - 33: {fileID: 3363460}
-  - 23: {fileID: 2363460}
+  - component: {fileID: 463460}
+  - component: {fileID: 3363460}
+  - component: {fileID: 2363460}
   m_Layer: 0
   m_Name: Graphics
   m_TagString: Untagged
@@ -114,6 +115,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 450054}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &450054
 Transform:
   m_ObjectHideFlags: 1
@@ -127,6 +129,7 @@ Transform:
   - {fileID: 450052}
   m_Father: {fileID: 450056}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &450056
 Transform:
   m_ObjectHideFlags: 1
@@ -140,6 +143,7 @@ Transform:
   - {fileID: 450054}
   m_Father: {fileID: 450058}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &450058
 Transform:
   m_ObjectHideFlags: 1
@@ -153,6 +157,7 @@ Transform:
   - {fileID: 450056}
   m_Father: {fileID: 463458}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &463458
 Transform:
   m_ObjectHideFlags: 1
@@ -167,6 +172,7 @@ Transform:
   - {fileID: 450058}
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &463460
 Transform:
   m_ObjectHideFlags: 1
@@ -179,6 +185,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 463458}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!20 &2050052
 Camera:
   m_ObjectHideFlags: 1
@@ -256,17 +263,22 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 10302, guid: 0000000000000000f000000000000000, type: 0}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 0
-  m_ReflectionProbeUsage: 1
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
@@ -380,17 +392,20 @@ MonoBehaviour:
     slopeSpeedMultiplier:
       serializedVersion: 2
       m_Curve:
-      - time: -90
+      - serializedVersion: 2
+        time: -90
         value: 1
         inSlope: 0
         outSlope: 0
         tangentMode: 0
-      - time: 0
+      - serializedVersion: 2
+        time: 0
         value: 1
         inSlope: 0
         outSlope: 0
         tangentMode: 0
-      - time: 90
+      - serializedVersion: 2
+        time: 90
         value: 0
         inSlope: 0
         outSlope: 0
@@ -436,3 +451,17 @@ Prefab:
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 163458}
   m_IsPrefabParent: 1
+--- !u!114 &114111526175316250
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 150058}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3bd92c411e0576c4aad0b30645a3d4c7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fixAspectRatio: 1
+  mirrorCamera: {fileID: 0}
+  fillTexture: {fileID: 0}

--- a/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/DisplayController.cs
@@ -70,8 +70,6 @@ namespace OSVR
             public VRViewer[] Viewers { get { return _viewers; } }
             public uint ViewerCount { get { return _viewerCount; } }
             public OsvrRenderManager RenderManager { get { return _renderManager; } }
-            [Tooltip("Renders an extra camera to show what the HMD user sees while in Direct Mode. Comes at a framerate cost until this feature becomes part of RenderManager.")]
-            public bool showDirectModePreview = false; //should the monitor show what the user sees in the HMD?
 
             public uint TotalDisplayWidth
             {

--- a/OSVR-Unity/Assets/OSVRUnity/src/OsvrMirrorDisplay.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/OsvrMirrorDisplay.cs
@@ -1,0 +1,142 @@
+﻿using UnityEngine;
+
+namespace OSVR
+{
+    namespace Unity
+    {
+        /// <summary>
+        /// OSVR Mirror Display draws a mirror view of the selected camera to the main display. The camera
+        /// defaults to the first VR Eye found in the scene, but any other camera can be specified.
+        /// 
+        /// Attach to any GameObject in the scene.
+        /// </summary>
+        public class OsvrMirrorDisplay : MonoBehaviour
+        {
+            #region Serialized Fields
+            [SerializeField]
+            [Tooltip("Corrects the aspect ratio of the mirror and draws the fill texture behind it.")]
+            private bool fixAspectRatio = true;
+            [SerializeField]
+            [Tooltip("The camera to duplicate in the mirror. Leave empty to find the camera on the first VR Eye in the scene.")]
+            private Camera mirrorCamera;
+            [SerializeField]
+            [Tooltip("The texture to draw behind the mirror. Leave empty to use a plain black texture.")]
+            private Texture2D fillTexture;
+            #endregion
+
+            #region Public Properties
+            /// <summary>
+            /// The camera we would like to mirror. Usually a child of a VR Eye.
+            /// </summary>
+            public Camera MirrorCamera
+            {
+                get { return mirrorCamera; }
+                set { mirrorCamera = value; }
+            }
+            /// <summary>
+            /// The texture to draw behind the mirror.
+            /// </summary>
+            public Texture2D FillTexture
+            {
+                get { return fillTexture; }
+                set { fillTexture = value; }
+            }
+            #endregion
+
+            #region Private Variables
+            private Rect _renderRect;
+            private Rect _fillRect;
+            #endregion
+
+            #region Magic Methods
+            void Awake()
+            {
+                if (mirrorCamera == null)
+                {
+                    mirrorCamera = FindObjectOfType<VREye>().GetComponentInChildren<Camera>();
+                }
+                if (fillTexture == null)
+                {
+                    fillTexture = new Texture2D(1, 1);
+                    fillTexture.SetPixel(1, 1, Color.black);
+                    fillTexture.wrapMode = TextureWrapMode.Repeat;
+                    fillTexture.Apply();
+                }
+            }
+
+            private void OnGUI()
+            {
+                if (Event.current.type.Equals(EventType.Repaint))
+                {
+                    RefreshRectangles();
+                    if (fixAspectRatio)
+                    {
+                        DrawFill();
+                    }
+                    DrawTexture();
+                }
+            }
+            #endregion
+
+            #region Private Methods
+            private void DrawTexture()
+            {
+                Graphics.DrawTexture(_renderRect, mirrorCamera.targetTexture);
+            }
+
+            private void DrawFill()
+            {
+                Graphics.DrawTexture(_fillRect, fillTexture);
+            }
+
+            private void RefreshRectangles()
+            {
+                // Get rendering width/height
+                // Using Display.renderingWidth seems not to work properly outside of the editor
+                // It appears to report the systemWidth or something weird instead. For now, use 
+                // Screen.width, which surprisingly works just fine in Extended Mode with a single
+                // monitor + HMD. Might cause issues for users with multi-monitor + HMD?
+                int rw = Screen.width;
+                int rh = Screen.height;
+
+                if (fixAspectRatio)
+                {
+                    int w = mirrorCamera.targetTexture.width;
+                    int h = mirrorCamera.targetTexture.height;
+
+                    // When HDK 1.4 or 2.0 are in "portrait" mode, the Render Texture
+                    // is apparently rendered taller than it is wide, but is inexplicably NOT
+                    // rotated. This creates a "squished" effect that is simply fixed by 
+                    // swapping width and height. Unknown if this would create a problem
+                    // for headsets that do not exhibit this behavior.
+                    if (h > w)
+                    {
+                        int swap = w;
+                        w = h;
+                        h = swap;
+                    }
+
+                    // Calculate the necessary scaling to fit the renderTarget on the
+                    // display while maintaining constant aspect ratio
+                    float minW = Mathf.Min(w, rw);
+                    float minH = Mathf.Min(h, rh);
+                    float scaleW = minW / (float)w;
+                    float scaleH = minH / (float)h;
+                    float scalar = Mathf.Min(scaleW, scaleH);
+
+                    w = Mathf.FloorToInt(w * scalar);
+                    h = Mathf.FloorToInt(h * scalar);
+                    int x = (rw - w) / 2;
+                    int y = (rh - h) / 2;
+                    _renderRect = new Rect(x, y, w, h);
+                    _fillRect = new Rect(0, 0, rw, rh);
+                }
+                else
+                {
+                    _renderRect = new Rect(0, 0, rw, rh);
+                }
+            }
+            #endregion
+        }
+    }
+}

--- a/OSVR-Unity/Assets/OSVRUnity/src/OsvrMirrorDisplay.cs.meta
+++ b/OSVR-Unity/Assets/OSVRUnity/src/OsvrMirrorDisplay.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3bd92c411e0576c4aad0b30645a3d4c7
+timeCreated: 1491958061
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
@@ -295,12 +295,7 @@ namespace OSVR
 #if UNITY_5_2 || UNITY_5_3 || UNITY_5_4 || UNITY_5_5 || UNITY_5_6
                         GL.Viewport(_emptyViewport);
                         GL.Clear(false, true, Camera.backgroundColor);                      
-                        GL.IssuePluginEvent(DisplayController.RenderManager.GetRenderEventFunction(), OsvrRenderManager.RENDER_EVENT); 
-                        if(DisplayController.showDirectModePreview)
-                        {
-                            Camera.Render();
-                        } 
-                                             
+                        GL.IssuePluginEvent(DisplayController.RenderManager.GetRenderEventFunction(), OsvrRenderManager.RENDER_EVENT);                    
 #else
                         Debug.LogError("[OSVR-Unity] GL.IssuePluginEvent failed. This version of Unity cannot support RenderManager.");
                         DisplayController.UseRenderManager = false;


### PR DESCRIPTION
Adds a new component, OsvrMirrorDisplay, that is much more performant than the Direct Mode Preview. Works by drawing the render target of a specified camera to the screen. Similar to #193, but higher level. In complex scenes, the profiler shows significant savings in frame times. In my own tests, a scene that stutters to as low as 50FPS with Direct Mode Preview remains at 90 FPS with this mirror [~9 ms!]

By default, the mirror locks the aspect ratio to that of the camera it duplicates and scales to fit the active display. It also, by default, fills in the "empty" space with a plain black texture. Users can specify an alternative "fill texture" to be rendered behind the mirror if they so choose, either in the Inspector or by setting the FillTexture property on the component. Or, they can disable this functionality altogether by unchecking FixAspectRatio in the Inspector.

By default, the camera to be mirrored is the first VREye found in the scene. However, users can specify an alternate camera either in the Inspector or by setting the MirrorCamera property on the component.

I've tested on both an HDK 1.4 and HDK 2.0 with good results, and in both Extended and Direct mode with the "mirror window" in both fullscreen and windowed mode

I have not tested on older versions of Unity, but I do not believe the functionality in any of the methods used has changed in a very long time.