### PR TITLE
Fixed WSA compilation and added compatibility with Unity 2017

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/OsvrRenderManager.cs
@@ -70,6 +70,21 @@ namespace OSVR
             private static readonly IntPtr functionPointer = Marshal.GetFunctionPointerForDelegate(debugLog);
             private static void DebugWrapper(string log) { Debug.Log(log); }
 
+#if UNITY_METRO
+            private static Byte ConstructRenderBuffers() { return 0; }
+            private static Byte CreateRenderManagerFromUnity(OSVR.ClientKit.SafeClientContextHandle ctx) { return 0; }
+            private static OSVR.ClientKit.Pose3 GetEyePose(int eye) { return new OSVR.ClientKit.Pose3(); }
+            private static OSVR_ProjectionMatrix GetProjectionMatrix(int eye) { return new OSVR_ProjectionMatrix(); }
+            private static IntPtr GetRenderEventFunc() { return IntPtr.Zero; }
+            private static OSVR_ViewportDescription GetViewport(int eye) { return new OSVR_ViewportDescription(); }
+            private static void LinkDebug([MarshalAs(UnmanagedType.FunctionPtr)]IntPtr debugCal) { }
+            private static int SetColorBufferFromUnity(System.IntPtr texturePtr, int eye) { return 0; }
+            private static void SetFarClipDistance(double farClipPlaneDistance) { }
+            private static void SetIPD(double ipdMeters) { }
+            private static void SetNearClipDistance(double nearClipPlaneDistance) { }
+            private static void ShutdownRenderManager() { }
+#else
+
             //Create and Register RenderBuffers
             [DllImport(PluginName)]
             private static extern Byte 
@@ -126,6 +141,8 @@ namespace OSVR
             [DllImport(PluginName)]
             private static extern void
                 ShutdownRenderManager();
+
+#endif
 
             // UnityPluginLoad is not needed
             // UnityPluginUnload is not needed
@@ -220,7 +237,7 @@ namespace OSVR
             //"Recenter" based on current head orientation
             public void SetRoomRotationUsingHead()
             {
-#if UNITY_5_2 || UNITY_5_3 || UNITY_5_4 || UNITY_5_5 || UNITY_5_6
+#if UNITY_5_2 || UNITY_5_3 || UNITY_5_4 || UNITY_5_5 || UNITY_5_6 || UNITY_2017
                 ClientKit.instance.context.SetRoomRotationUsingHead();
                 GL.IssuePluginEvent(GetRenderEventFunc(), 3);
 #endif
@@ -229,7 +246,7 @@ namespace OSVR
             //Clear the room-to-world transform, undo a call to SetRoomRotationUsingHead
             public void ClearRoomToWorldTransform()
             {
-#if UNITY_5_2 || UNITY_5_3 || UNITY_5_4 || UNITY_5_5 || UNITY_5_6
+#if UNITY_5_2 || UNITY_5_3 || UNITY_5_4 || UNITY_5_5 || UNITY_5_6 || UNITY_2017
                 ClientKit.instance.context.ClearRoomToWorldTransform();
                 GL.IssuePluginEvent(GetRenderEventFunc(), 4);
 #endif

--- a/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
@@ -187,7 +187,7 @@ namespace OSVR
                 if (DisplayController.UseRenderManager)
                 {
                     //Update RenderInfo
-#if UNITY_5_2 || UNITY_5_3 || UNITY_5_4 || UNITY_5_5 || UNITY_5_6
+#if UNITY_5_2 || UNITY_5_3 || UNITY_5_4 || UNITY_5_5 || UNITY_5_6 || UNITY_2017
                     GL.IssuePluginEvent(DisplayController.RenderManager.GetRenderEventFunction(), OsvrRenderManager.UPDATE_RENDERINFO_EVENT);
 #else
                     Debug.LogError("[OSVR-Unity] GL.IssuePluginEvent failed. This version of Unity cannot support RenderManager.");
@@ -292,7 +292,7 @@ namespace OSVR
                     if (DisplayController.UseRenderManager && DisplayController.CheckDisplayStartup())
                     {
                         // Issue a RenderEvent, which copies Unity RenderTextures to RenderManager buffers
-#if UNITY_5_2 || UNITY_5_3 || UNITY_5_4 || UNITY_5_5 || UNITY_5_6
+#if UNITY_5_2 || UNITY_5_3 || UNITY_5_4 || UNITY_5_5 || UNITY_5_6|| UNITY_2017
                         GL.Viewport(_emptyViewport);
                         GL.Clear(false, true, Camera.backgroundColor);                      
                         GL.IssuePluginEvent(DisplayController.RenderManager.GetRenderEventFunction(), OsvrRenderManager.RENDER_EVENT);                    


### PR DESCRIPTION
Hi,
This PR does two things, first it adds Unity 2017 compatibility, second, it allows a project to be compiled on the Universal Windows  Platform.
However to be compatible, you have to merge [this PR from the Managed-OSVR repository](https://github.com/OSVR/Managed-OSVR/pull/42). 

* Create a folder called WSA and copy the dll for Windows 10
* `OSVR.ClientKit.dll` in the root folder **MUST be excluded** from the Windows Store target
* The wsa version **MUST be included** for Windows Store target AND you have to **check placeholder**.

I can do it when the Managed-OSVR is merged and added into this project.