### PR TITLE
More future-proof RenderManager compatibility check

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/VRViewer.cs
@@ -186,8 +186,9 @@ namespace OSVR
             {
                 if (DisplayController.UseRenderManager)
                 {
-                    //Update RenderInfo
-#if UNITY_5_2 || UNITY_5_3 || UNITY_5_4 || UNITY_5_5 || UNITY_5_6 || UNITY_2017
+                    // Update RenderInfo
+                    // RenderManager supported on unity 5.2+
+#if !(UNITY_5_1 || UNIT_5_0 || UNITY_4_7 || UNITY_4_6)
                     GL.IssuePluginEvent(DisplayController.RenderManager.GetRenderEventFunction(), OsvrRenderManager.UPDATE_RENDERINFO_EVENT);
 #else
                     Debug.LogError("[OSVR-Unity] GL.IssuePluginEvent failed. This version of Unity cannot support RenderManager.");
@@ -292,7 +293,8 @@ namespace OSVR
                     if (DisplayController.UseRenderManager && DisplayController.CheckDisplayStartup())
                     {
                         // Issue a RenderEvent, which copies Unity RenderTextures to RenderManager buffers
-#if UNITY_5_2 || UNITY_5_3 || UNITY_5_4 || UNITY_5_5 || UNITY_5_6 || UNITY_2017
+                        // RenderManager supported on unity 5.2+
+#if !(UNITY_5_1 || UNIT_5_0 || UNITY_4_7 || UNITY_4_6)
                         GL.Viewport(_emptyViewport);
                         GL.Clear(false, true, Camera.backgroundColor);                      
                         GL.IssuePluginEvent(DisplayController.RenderManager.GetRenderEventFunction(), OsvrRenderManager.RENDER_EVENT);                    


### PR DESCRIPTION
Previously we white-listed unity versions that could run RenderManager, but this breaks with every new Unity version. The reversed condition doesn't work for unity versions older than 4.6 (I don't believe we support them anyway) but won't break with every new version. 