### PR TITLE
This compiles with Unity version 2019.1.0f2

### DIFF
--- a/OSVR-Unity/Assets/OSVRUnity/src/OsvrUnityNativeVR.cs
+++ b/OSVR-Unity/Assets/OSVRUnity/src/OsvrUnityNativeVR.cs
@@ -29,7 +29,7 @@
 using OSVR.Unity;
 using System.Collections;
 using UnityEngine;
-using UnityEngine.VR;
+using UnityEngine.XR;
 using System;
 
 namespace OSVR
@@ -128,11 +128,11 @@ namespace OSVR
 #if UNITY_2017
                 if(_clientKit.context.CheckStatus())
                 {
-                    VRDevice.DisableAutoVRCameraTracking(_camera0, true);
+                    XRDevice.DisableAutoVRCameraTracking(_camera0, true);
                 }
 
 #endif
-                VRSettings.showDeviceView = false;
+                XRSettings.showDeviceView = false;
 
                 //Application.targetFrameRate = 90;
                 Application.targetFrameRate = -1;
@@ -177,7 +177,7 @@ namespace OSVR
                         {
                             Debug.LogError("[OSVR-Unity] Failed to create RenderManager.");
                             _renderManagerConfigFound = false;
-                            VRSettings.enabled = false; //disable VR mode
+                            XRSettings.enabled = false; //disable VR mode
                         }
                     }
                 }
@@ -268,13 +268,13 @@ namespace OSVR
             private void SetRenderScale()
             {
                 //@todo
-                //VRSettings.renderScale = overfill_factor;
+                //XRSettings.renderScale = overfill_factor;
             }
 
             private void SetRenderViewportScale()
             {
                 //@todo
-                //VRSettings.renderViewportScale = overfill_factor;
+                //XRSettings.renderViewportScale = overfill_factor;
             }
 
             //Set RenderManager rendering parameters: near and far clip plane distance, projection matrices
@@ -534,21 +534,21 @@ namespace OSVR
 
                     //Retrieves the number of dropped frames reported by the VR SDK.
                     int droppedFrames;
-                    if (VRStats.TryGetDroppedFrameCount(out droppedFrames))
+                    if (XRStats.TryGetDroppedFrameCount(out droppedFrames))
                     {
                         GUI.Label(new Rect(0, 0, 200, 200), "Dropped frames: " + droppedFrames);
                     }
 
                     //Retrieves the number of times the current frame has been drawn to the device as reported by the VR SDK.
                     int framePresentCount;
-                    if (VRStats.TryGetFramePresentCount(out framePresentCount))
+                    if (XRStats.TryGetFramePresentCount(out framePresentCount))
                     {
                         GUI.Label(new Rect(0, 200, 200, 200), "Frame Present Count: " + framePresentCount);
                     }
 
                     //Retrieves the time spent by the GPU last frame, in seconds, as reported by the VR SDK.
                     float gpuTimeSpentLastFrame;
-                    if (VRStats.TryGetGPUTimeLastFrame(out gpuTimeSpentLastFrame))
+                    if (XRStats.TryGetGPUTimeLastFrame(out gpuTimeSpentLastFrame))
                     {
                         GUI.Label(new Rect(0, 400, 200, 200), "GPU Time spent last frame: " + gpuTimeSpentLastFrame);
                     }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ OSVR-Unity uses the OSVR-RenderManager library for direct-mode rendering, lens c
 
 These libraries are copied over to the Plugins directory in our CI build, and are not included in the source.
 
+If you want to build support for this into the plugin, you need to copy the osvrUnityRenderingPlugin.dll that is built with that project into the Managed-OSVR-Unity subdirectory for each build type (x86_64 and x86) before running the install-managed-osvr.cmd script below.  You also need to copy all of the DLLs from the OSVR-RenderManager build directory into these locations as well as the DLLs from the OSVR-Core build (it may be that some of these are not needed, but skipping this copy step has in the past produced plug-ins that could not load the Rendermanager plug-in because of missing dependencies).
+
 ## OSVR Unity Integration
 [Step-by-step getting started guide](https://github.com/OSVR/OSVR-Unity/blob/master/GettingStarted.md)
 

--- a/build-unity-packages.cmd
+++ b/build-unity-packages.cmd
@@ -3,7 +3,7 @@ cd /d %~dp0
 rem Check to make sure we've actually copied over at least something that could be the OSVR and Managed-OSVR binaries.
 if not exist OSVR-Unity\Assets\OSVRUnity\Plugins\x86\*.dll exit /B 1
 
-"C:\Program Files\Unity\Editor\Unity.exe" -quit -batchmode -projectPath "%~dp0OSVR-Unity" -logFile "%~dp0unity.log" -executeMethod OSVRUnityBuild.build
+"C:\Program Files\Unity\Hub\Editor\2019.1.0f2\Editor\Unity.exe" -quit -batchmode -projectPath "%~dp0OSVR-Unity" -logFile "%~dp0unity.log" -executeMethod OSVRUnityBuild.build
 type "%~dp0unity.log"
 
 rem Fail the build if we didn't get a unitypackage out.


### PR DESCRIPTION
It also updates the README to describe all of the DLLs that need to be copied to make the RenderManager plug-in work.